### PR TITLE
Switch image proxy from caching to redirect mode

### DIFF
--- a/backend/src/routes/image-proxy.js
+++ b/backend/src/routes/image-proxy.js
@@ -1,38 +1,15 @@
 const express = require('express');
 const router = express.Router();
-const axios = require('axios');
-const crypto = require('crypto');
 const { requireAuth, requireAdmin } = require('./auth');
-const { validateUrlForSSRF, isPrivateIP } = require('../utils/ssrf-guard');
+const { validateUrlForSSRF } = require('../utils/ssrf-guard');
 const { audit } = require('../services/audit-log');
-
-// In-memory cache for images with size limit
-const imageCache = new Map();
-const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
-const MAX_CACHE_ENTRIES = 500;
-const MAX_IMAGE_SIZE = 2 * 1024 * 1024; // 2MB per image
-const MAX_CACHE_BYTES = 256 * 1024 * 1024; // 256MB total cache memory cap
-let cacheBytes = 0;
-
-// Cache cleanup interval
-setInterval(
-  () => {
-    const now = Date.now();
-    for (const [key, value] of imageCache.entries()) {
-      if (now - value.timestamp > CACHE_TTL) {
-        cacheBytes -= value.data.length;
-        imageCache.delete(key);
-      }
-    }
-  },
-  60 * 60 * 1000,
-); // Clean every hour
 
 /**
  * GET /api/v1/image-proxy
- * Proxy and cache channel logo images
+ * Validate a logo URL for safety (SSRF, protocol) then 302 redirect to the original.
+ * No bytes are proxied or cached — the browser fetches directly from the origin.
  * Query params:
- *   - url: The image URL to fetch
+ *   - url: The image URL to redirect to
  */
 // Allow auth via query params for browser-initiated requests (e.g. <img src="...">)
 router.get(
@@ -77,75 +54,10 @@ router.get(
         });
       }
 
-      // Create cache key from URL
-      const cacheKey = crypto.createHash('sha256').update(url).digest('hex');
-
-      // Check cache
-      const cached = imageCache.get(cacheKey);
-      if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-        res.set('Content-Type', cached.contentType);
-        res.set('X-Content-Type-Options', 'nosniff');
-        res.set('Cache-Control', 'public, max-age=86400'); // 24 hours
-        res.set('X-Cache', 'HIT');
-        return res.send(cached.data);
-      }
-
-      // Fetch image
-      const response = await axios.get(url, {
-        responseType: 'arraybuffer',
-        timeout: 10000,
-        maxRedirects: 5,
-        maxContentLength: 10 * 1024 * 1024,
-        headers: {
-          'User-Agent': 'FireVision-IPTV-Server/1.0',
-        },
-        beforeRedirect: (options) => {
-          const hostname = (options.hostname || '').replace(/^\[|\]$/g, '');
-          if (
-            isPrivateIP(hostname) ||
-            ['localhost', 'metadata.google.internal'].includes(hostname.toLowerCase())
-          ) {
-            throw new Error('Redirect to private/internal address blocked');
-          }
-        },
-      });
-
-      const rawContentType = response.headers['content-type'] || 'image/jpeg';
-      // Validate Content-Type is an image to prevent serving HTML/JS under our origin
-      if (!rawContentType.startsWith('image/')) {
-        // Not an image – return placeholder instead of proxying arbitrary content
-        const placeholderPng = Buffer.from(
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-          'base64',
-        );
-        res.set('Content-Type', 'image/png');
-        res.set('X-Content-Type-Options', 'nosniff');
-        res.set('Cache-Control', 'public, max-age=300');
-        return res.send(placeholderPng);
-      }
-      const contentType = rawContentType;
-      const imageData = Buffer.from(response.data);
-
-      // Only cache if within size limits (entry size, count, and total memory)
-      if (
-        imageData.length <= MAX_IMAGE_SIZE &&
-        imageCache.size < MAX_CACHE_ENTRIES &&
-        cacheBytes + imageData.length <= MAX_CACHE_BYTES
-      ) {
-        imageCache.set(cacheKey, {
-          data: imageData,
-          contentType: contentType,
-          timestamp: Date.now(),
-        });
-        cacheBytes += imageData.length;
-      }
-
-      // Send response
-      res.set('Content-Type', contentType);
+      // Redirect to the original URL — browser fetches the image directly
+      res.set('Cache-Control', 'public, max-age=86400'); // browsers cache the redirect for 24h
       res.set('X-Content-Type-Options', 'nosniff');
-      res.set('Cache-Control', 'public, max-age=86400');
-      res.set('X-Cache', 'MISS');
-      res.send(imageData);
+      res.redirect(302, url);
     } catch (error) {
       console.error('Image proxy error:', error.message);
 
@@ -157,7 +69,7 @@ router.get(
 
       res.set('Content-Type', 'image/png');
       res.set('X-Content-Type-Options', 'nosniff');
-      res.set('Cache-Control', 'public, max-age=300'); // Cache errors for 5 minutes
+      res.set('Cache-Control', 'public, max-age=300');
       res.send(placeholderPng);
     }
   },
@@ -165,34 +77,23 @@ router.get(
 
 /**
  * GET /api/v1/image-proxy/stats
- * Get cache statistics
+ * Returns proxy mode info (no cache to report since we use redirect mode)
  */
 router.get('/stats', requireAuth, requireAdmin, (req, res) => {
-  const stats = {
-    cacheSize: imageCache.size,
-    cacheTTL: CACHE_TTL,
-    entries: Array.from(imageCache.entries()).map(([key, value]) => ({
-      key,
-      size: value.data.length,
-      contentType: value.contentType,
-      age: Date.now() - value.timestamp,
-    })),
-  };
-
   res.json({
     success: true,
-    data: stats,
+    data: {
+      mode: 'redirect',
+      description: 'Image proxy validates URLs and redirects to the original source. No server-side caching.',
+    },
   });
 });
 
 /**
  * DELETE /api/v1/image-proxy/cache
- * Clear image cache
+ * No-op in redirect mode — kept for API compatibility
  */
 router.delete('/cache', requireAuth, requireAdmin, (req, res) => {
-  const sizeBefore = imageCache.size;
-  imageCache.clear();
-  cacheBytes = 0;
   audit({
     userId: req.user.id,
     action: 'clear_image_cache',
@@ -203,8 +104,8 @@ router.delete('/cache', requireAuth, requireAdmin, (req, res) => {
 
   res.json({
     success: true,
-    message: 'Image cache cleared',
-    itemsCleared: sizeBefore,
+    message: 'Image proxy uses redirect mode — no server-side cache to clear',
+    itemsCleared: 0,
   });
 });
 


### PR DESCRIPTION
## Summary
Refactored the image proxy endpoint to use HTTP 302 redirects instead of server-side caching. The proxy now validates URLs for SSRF vulnerabilities and redirects browsers directly to the original image source, eliminating the need for in-memory image caching infrastructure.

## Key Changes
- **Removed in-memory caching**: Deleted all cache management code including the `imageCache` Map, TTL logic, cache cleanup interval, and memory limit enforcement (256MB cap, 500 entry limit, 2MB per image)
- **Replaced proxying with redirects**: Changed the main endpoint to perform SSRF validation and return a 302 redirect to the original URL instead of fetching and serving image bytes
- **Simplified dependencies**: Removed `axios` and `crypto` imports (no longer needed for fetching or cache key generation)
- **Removed SSRF redirect validation**: Eliminated the `isPrivateIP` check in axios `beforeRedirect` hook since we no longer fetch images server-side
- **Updated `/stats` endpoint**: Now returns proxy mode information instead of cache statistics
- **Updated `/cache` DELETE endpoint**: Converted to a no-op that returns a message indicating redirect mode has no server-side cache

## Implementation Details
- The endpoint still validates the URL using `validateUrlForSSRF()` before redirecting, maintaining security against SSRF attacks
- Error handling returns a placeholder PNG on validation failure, preserving the existing error behavior
- Cache-Control headers are set to 24 hours, allowing browsers to cache the redirect response
- The `/cache` endpoint is retained for API compatibility but performs no actual cache clearing
