### PR TITLE
Fix list-related bugs in admin search, channel stats, and parseInt calls

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -358,11 +358,11 @@ router.get('/channels', async (req, res) => {
     // Text search across name and group
     if (search) {
       const regex = new RegExp(escapeRegex(search), 'i');
-      filter.$or = [{ channelName: regex }, { name: regex }, { channelGroup: regex }];
+      filter.$or = [{ channelName: regex }, { channelGroup: regex }];
     }
 
-    const p = parseInt(page) || 1;
-    const ps = Math.min(parseInt(pageSize) || 50, 200);
+    const p = parseInt(page, 10) || 1;
+    const ps = Math.min(parseInt(pageSize, 10) || 50, 200);
 
     const [channels, totalCount] = await Promise.all([
       Channel.find(filter)

--- a/backend/src/routes/channel-test.js
+++ b/backend/src/routes/channel-test.js
@@ -227,8 +227,8 @@ router.post('/test-all', async (req, res) => {
     }
 
     const channels = await Channel.find({})
-      .limit(Math.min(parseInt(limit) || 50, 200))
-      .skip(parseInt(skip) || 0);
+      .limit(Math.min(parseInt(limit, 10) || 50, 200))
+      .skip(parseInt(skip, 10) || 0);
 
     const results = [];
 

--- a/backend/src/routes/iptv-org.js
+++ b/backend/src/routes/iptv-org.js
@@ -175,7 +175,7 @@ router.get('/api/streams', async (req, res) => {
     const { channels, total } = await iptvOrgCacheService.getEnrichedChannels({
       country,
       category,
-      limit: limit ? parseInt(limit) : undefined,
+      limit: limit ? parseInt(limit, 10) : undefined,
     });
     res.json({ success: true, count: total, data: channels });
   } catch (error) {
@@ -193,7 +193,7 @@ router.get('/api/enriched', async (req, res) => {
       category,
       language,
       status,
-      limit: parseInt(limit),
+      limit: parseInt(limit, 10),
     });
 
     // Map to frontend-compatible shape
@@ -241,8 +241,8 @@ router.get('/api/grouped', async (req, res) => {
       category: category || undefined,
       status: status || undefined,
       search: search || undefined,
-      limit: parseInt(limit),
-      skip: parseInt(skip),
+      limit: parseInt(limit, 10),
+      skip: parseInt(skip, 10),
     });
 
     res.json({

--- a/backend/src/routes/scheduler.js
+++ b/backend/src/routes/scheduler.js
@@ -24,8 +24,8 @@ router.get('/runs', async (req, res) => {
   try {
     const { page, pageSize, taskName } = req.query;
     const result = await schedulerService.getRuns({
-      page: page ? parseInt(page) : 1,
-      pageSize: pageSize ? parseInt(pageSize) : 20,
+      page: page ? parseInt(page, 10) : 1,
+      pageSize: pageSize ? parseInt(pageSize, 10) : 20,
       taskName: taskName || undefined,
     });
     res.json({ success: true, ...result });

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -67,8 +67,8 @@ router.get('/', requireAuth, requireAdmin, async (req, res) => {
       filter.$or = [{ username: regex }, { email: regex }, { channelListCode: regex }];
     }
 
-    const p = parseInt(page) || 1;
-    const ps = Math.min(parseInt(pageSize) || 50, 200);
+    const p = parseInt(page, 10) || 1;
+    const ps = Math.min(parseInt(pageSize, 10) || 50, 200);
 
     const [users, totalCount] = await Promise.all([
       User.find(filter)

--- a/frontend/src/components/channels-page-shell.tsx
+++ b/frontend/src/components/channels-page-shell.tsx
@@ -692,7 +692,7 @@ export default function ChannelsPageShell({ mode }: ChannelsPageShellProps) {
   }
 
   async function handleTestAllUser() {
-    const toTest = userPaginated.length > 0 ? userPaginated : channels.slice(0, PAGE_SIZE);
+    const toTest = filtered.length > 0 ? filtered : channels.slice(0, PAGE_SIZE);
     if (toTest.length === 0) return;
     setTestingAll(true);
     setTestResults(null);
@@ -1306,7 +1306,7 @@ export default function ChannelsPageShell({ mode }: ChannelsPageShellProps) {
 
       {/* Stream health stats */}
       {(() => {
-        const list = isAdmin ? channels : channels;
+        const list = isAdmin ? channels : filtered;
         const working = list.filter((c) => c.metadata?.isWorking === true).length;
         const notWorking = list.filter((c) => c.metadata?.isWorking === false).length;
         const untested = list.length - working - notWorking;


### PR DESCRIPTION
## Summary

- **Fix invalid field in admin channel search**: Removed non-existent `name` field from `$or` query in `admin.js` — the Channel model only has `channelName`, so searching `name` always returned no matches for that branch
- **Fix broken ternary in stream health stats**: `isAdmin ? channels : channels` always used the full channel list; non-admin users now correctly see stats for their `filtered` channels only
- **Fix handleTestAllUser() testing only current page**: Changed from `userPaginated` (current page only) to `filtered` (all filtered channels) so "Test All" actually tests all matching channels
- **Add missing radix to parseInt() calls**: Added explicit radix `10` to all `parseInt()` calls across 5 backend route files (admin, users, scheduler, channel-test, iptv-org)

## Test plan

- [ ] Admin channel search: verify searching returns correct results (no phantom `name` field matches)
- [ ] Non-admin user channel page: verify stream health stats (working/not working/untested) reflect filtered results, not all channels
- [ ] Non-admin "Test All" button: verify it tests all filtered channels, not just the current page
- [ ] Pagination: verify page/pageSize query params work correctly across all list endpoints