### PR TITLE
Add build-time environment variables for frontend Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -87,6 +87,9 @@ jobs:
           push: true
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
+          build-args: |
+            GA_MEASUREMENT_ID=${{ vars.GA_MEASUREMENT_ID }}
+            FRONTEND_SENTRY_DSN=${{ secrets.FRONTEND_SENTRY_DSN }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-frontend:${{ steps.vars.outputs.version }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-frontend:latest

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -17,6 +17,13 @@ RUN npx -w @firevision/shared tsc
 
 # Copy frontend source and build
 COPY frontend/ ./frontend/
+
+# Build-time env vars for Next.js static rendering
+ARG GA_MEASUREMENT_ID
+ARG FRONTEND_SENTRY_DSN
+ENV GA_MEASUREMENT_ID=$GA_MEASUREMENT_ID
+ENV FRONTEND_SENTRY_DSN=$FRONTEND_SENTRY_DSN
+
 RUN mkdir -p frontend/public && npm run build -w @firevision/frontend
 
 # --- Production stage ---


### PR DESCRIPTION
This pull request updates the Docker build and deployment process to support build-time environment variables for analytics and error tracking in the frontend. The main changes involve passing Google Analytics and Sentry DSN values into the frontend build, ensuring these values are available during static rendering.

**Docker build process improvements:**

* Added `GA_MEASUREMENT_ID` and `FRONTEND_SENTRY_DSN` as build arguments and environment variables in `Dockerfile.frontend` to make them available during Next.js static rendering.
* Updated `.github/workflows/docker-publish.yml` to pass `GA_MEASUREMENT_ID` and `FRONTEND_SENTRY_DSN` as build arguments when building the frontend Docker image.