### PR TITLE
fix: enforce channel ownership boundary (Greptile P1s from #51)

### DIFF
--- a/backend/src/routes/channels.js
+++ b/backend/src/routes/channels.js
@@ -338,7 +338,7 @@ router.post('/', requireAuth, requireAdmin, async (req, res) => {
     } = req.body;
 
     if (channelId) {
-      const existing = await Channel.findOne({ channelId });
+      const existing = await Channel.findOne({ channelId, ownerId: null });
       if (existing) {
         return res
           .status(400)
@@ -414,8 +414,9 @@ router.put('/:id', requireAuth, requireAdmin, async (req, res) => {
     if (alternateStreams !== undefined) allowedUpdates.alternateStreams = alternateStreams;
     if (flaggedBad !== undefined) allowedUpdates.flaggedBad = flaggedBad;
 
-    const channel = await Channel.findByIdAndUpdate(
-      req.params.id,
+    // Scope to the shared catalog so an admin can't mutate a user's private channel
+    const channel = await Channel.findOneAndUpdate(
+      { _id: req.params.id, ownerId: null },
       { $set: allowedUpdates },
       { new: true, runValidators: true },
     );
@@ -441,7 +442,7 @@ router.put('/:id', requireAuth, requireAdmin, async (req, res) => {
 // Delete channel (admin only)
 router.delete('/:id', requireAuth, requireAdmin, async (req, res) => {
   try {
-    const channel = await Channel.findByIdAndDelete(req.params.id);
+    const channel = await Channel.findOneAndDelete({ _id: req.params.id, ownerId: null });
     if (!channel) {
       return res.status(404).json({ success: false, error: 'Channel not found' });
     }

--- a/backend/src/routes/tv.js
+++ b/backend/src/routes/tv.js
@@ -408,7 +408,7 @@ router.get('/epg/:code', async (req, res) => {
     // Get user's channels
     let channels;
     if (user.role === 'Admin') {
-      channels = await Channel.find({}).sort({ channelGroup: 1, order: 1 }).lean();
+      channels = await Channel.find({ ownerId: null }).sort({ channelGroup: 1, order: 1 }).lean();
     } else {
       channels = await Channel.find({
         _id: { $in: user.channels },
@@ -474,7 +474,7 @@ router.get('/epg/:code/json', async (req, res) => {
     // Get user's channels
     let channels;
     if (user.role === 'Admin') {
-      channels = await Channel.find({}).sort({ channelGroup: 1, order: 1 }).lean();
+      channels = await Channel.find({ ownerId: null }).sort({ channelGroup: 1, order: 1 }).lean();
     } else {
       channels = await Channel.find({
         _id: { $in: user.channels },

--- a/backend/src/routes/user-playlist.js
+++ b/backend/src/routes/user-playlist.js
@@ -45,8 +45,12 @@ router.put('/me/channels', requireAuth, async (req, res) => {
       return res.status(400).json({ success: false, error: 'Invalid channel ID format' });
     }
 
-    // Validate channel IDs
-    const channels = await Channel.find({ _id: { $in: channelIds } });
+    // Validate channel IDs — only catalog channels or the user's own private imports,
+    // so a user can't add another user's private channel to their selection.
+    const channels = await Channel.find({
+      _id: { $in: channelIds },
+      $or: [{ ownerId: null }, { ownerId: req.user.id }],
+    });
     if (channels.length !== channelIds.length) {
       return res.status(400).json({ success: false, error: 'Some channel IDs are invalid' });
     }
@@ -88,7 +92,10 @@ router.post('/me/channels/add', requireAuth, async (req, res) => {
     if (!user) return res.status(404).json({ success: false, error: 'User not found' });
 
     const existingIds = new Set(user.channels.map((id) => id.toString()));
-    const validChannels = await Channel.find({ _id: { $in: channelIds } }).select('_id');
+    const validChannels = await Channel.find({
+      _id: { $in: channelIds },
+      $or: [{ ownerId: null }, { ownerId: req.user.id }],
+    }).select('_id');
     const validIds = validChannels.map((c) => c._id.toString());
 
     const toAdd = validIds.filter((id) => !existingIds.has(id));

--- a/backend/src/scheduler-entrypoint.ts
+++ b/backend/src/scheduler-entrypoint.ts
@@ -61,8 +61,11 @@ process.on('SIGINT', () => shutdown('SIGINT'));
 process.on('unhandledRejection', (reason) => {
   console.error('[scheduler-entrypoint] Unhandled promise rejection:', reason);
 });
+// An uncaught exception may have left in-memory state (locks, timers) invalid —
+// log and exit so the container restarts clean rather than running corrupted.
 process.on('uncaughtException', (err) => {
-  console.error('[scheduler-entrypoint] Uncaught exception:', err);
+  console.error('[scheduler-entrypoint] Uncaught exception, exiting for clean restart:', err);
+  process.exit(1);
 });
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Fixes the P1 findings Greptile raised on #51 (the channel-ownership feature merged with enforcement gaps). Without these, the ownership boundary the feature introduced was not actually enforced on several paths.

## Fixes
- **Admin can no longer mutate/delete private channels** — `PUT`/`DELETE /channels/:id` now scope to `ownerId: null` (`findOneAndUpdate`/`findOneAndDelete`), so an admin or the public demo hitting a private channel id gets a 404 instead of editing/deleting a user's import.
- **EPG no longer crosses the boundary** — the admin/demo TV M3U + EPG generators used `Channel.find({})`, leaking every user's private imports; now scoped to the shared catalog (`ownerId: null`).
- **Selection bypass closed** — `PUT /me/channels` and `POST /me/channels/add` now accept only catalog channels or the caller's own private channels (`$or: [{ ownerId: null }, { ownerId: req.user.id }]`), so a user can't add another user's private channel by id and read it.
- **Per-owner dedup** — admin catalog create checks `{ channelId, ownerId: null }`, matching the per-owner unique index (a private channel's id no longer falsely blocks catalog creation).

## Also (Greptile finding on the hardening code)
- Scheduler `uncaughtException` handler now `exit(1)`s for a clean supervisor restart instead of continuing with possibly-corrupt in-memory state.

## Not included (deliberate)
- Heartbeat/lock-TTL reclaim finding — accepted: that's the designed TTL recovery behavior, and completion writes already guard on `lockedBy`.
- `initSuperAdmin` email-revert — pre-existing, not introduced here; tracked separately.

## Testing
Backend typecheck clean; eslint clean on all four changed files.
