### PR TITLE
Database optimization: growth prevention, serving performance, cleanup migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,11 +146,19 @@ LIVENESS_CHECK_INTERVAL_MS=86400000
 # Interval between EPG guide refreshes (default: 6 hours)
 EPG_REFRESH_INTERVAL_MS=21600000
 
+# How far ahead of "now" to keep EPG programs, in hours (default: 48 = ~2 days).
+# Bounds EPG storage — upstream XMLTV often carries ~6 days; anything beyond this is dropped on ingest.
+EPG_MAX_LOOKAHEAD_HOURS=48
+
 # Interval between IPTV-org cache refreshes (default: 1 hour)
 CACHE_REFRESH_INTERVAL_MS=3600000
 
 # Interval between stream health checks with auto-promotion (default: 4 hours)
 STREAM_HEALTH_CHECK_INTERVAL_MS=14400000
+
+# Prune stale dead cache rows after each liveness sweep (regenerable on next refresh). Off by default.
+# DEAD_STREAM_PRUNE_ENABLED=true
+# DEAD_STREAM_PRUNE_DAYS=7
 
 # Interval between YouTube stream URL refreshes (default: 4 hours)
 YOUTUBE_REFRESH_INTERVAL_MS=14400000
@@ -171,6 +179,10 @@ YT_DLP_CONCURRENCY=3
 
 # Max signup attempts per rate-limit window (default: 10)
 # SIGNUP_RATE_LIMIT_MAX=10
+
+# Max channels a user can hold in their personal list (default: 5000). Additions beyond
+# this are skipped; set the user's allCatalog flag instead for "wants everything" users.
+# USER_CHANNELS_MAX=5000
 
 # Concurrency for stream health checks (default: 10)
 # STREAM_HEALTH_CONCURRENCY=10

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,14 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "test": "jest",
-    "migrate:fix-indexes": "tsx src/scripts/migrations/0002-fix-indexes.ts"
+    "migrate:fix-indexes": "tsx src/scripts/migrations/0002-fix-indexes.ts",
+    "migrate:sync-indexes": "tsx src/scripts/migrations/0003-sync-indexes.ts",
+    "migrate:categorize": "tsx src/scripts/migrations/0004-categorize-backfill.ts",
+    "migrate:dedup-urls": "tsx src/scripts/migrations/0005-dedup-channel-urls.ts",
+    "migrate:epg-trim": "tsx src/scripts/migrations/0006-epg-trim.ts",
+    "migrate:prune-orphan-refs": "tsx src/scripts/migrations/0007-prune-orphan-refs.ts",
+    "migrate:categorize-patterns": "tsx src/scripts/migrations/0008-categorize-patterns.ts",
+    "migrate:fix-names": "tsx src/scripts/migrations/0009-fix-channel-names.ts"
   },
   "dependencies": {
     "@firevision/shared": "*",

--- a/backend/src/__tests__/import-helpers.test.ts
+++ b/backend/src/__tests__/import-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   capChannelAdditions,
   patternCategory,
   extractExtinfTitle,
+  repairLeakedExtinfName,
 } from '../services/import-helpers';
 
 describe('import-helpers', () => {
@@ -100,6 +101,32 @@ describe('import-helpers', () => {
 
     it('returns empty string when no title separator exists', () => {
       expect(extractExtinfTitle('#EXTINF:-1 tvg-id="x"')).toBe('');
+    });
+  });
+
+  describe('repairLeakedExtinfName', () => {
+    it('repairs a name with a leaked logo URL', () => {
+      expect(
+        repairLeakedExtinfName(
+          'fl_lossy,q_auto,h_250,w_250/https://cdn.example.com/x.png",Tata Play Marathi Classics',
+        ),
+      ).toBe('Tata Play Marathi Classics');
+    });
+
+    it('repairs a name with leaked user-agent attributes', () => {
+      expect(
+        repairLeakedExtinfName(
+          'like Gecko Chrome/76.0.3809.25 Safari/537.36" group-title="News",24 TV (1080p)',
+        ),
+      ).toBe('24 TV (1080p)');
+    });
+
+    it('leaves a legitimate title containing quote-comma untouched', () => {
+      expect(repairLeakedExtinfName('Show "Name", Extended')).toBeNull();
+    });
+
+    it('returns null when there is no quote-comma at all', () => {
+      expect(repairLeakedExtinfName('Plain Channel Name')).toBeNull();
     });
   });
 

--- a/backend/src/__tests__/import-helpers.test.ts
+++ b/backend/src/__tests__/import-helpers.test.ts
@@ -1,0 +1,161 @@
+import Channel from '../models/Channel';
+import { IptvOrgChannel } from '../models/IptvOrgCache';
+import {
+  clubByChannelId,
+  resolveChannelGroups,
+  dedupAgainstCatalog,
+  capChannelAdditions,
+  patternCategory,
+  extractExtinfTitle,
+} from '../services/import-helpers';
+
+describe('import-helpers', () => {
+  describe('clubByChannelId', () => {
+    it('folds same tvg-id entries into alternateStreams', () => {
+      const out = clubByChannelId([
+        { channelId: 'BBC.uk', channelName: 'BBC', channelUrl: 'http://a' },
+        { channelId: 'BBC.uk', channelName: 'BBC', channelUrl: 'http://b' },
+        { channelId: 'CNN.us', channelName: 'CNN', channelUrl: 'http://c' },
+      ]);
+      expect(out).toHaveLength(2);
+      const bbc = out.find((c) => c.channelId === 'BBC.uk');
+      expect(bbc.channelUrl).toBe('http://a');
+      expect(bbc.alternateStreams).toHaveLength(1);
+      expect(bbc.alternateStreams[0].streamUrl).toBe('http://b');
+    });
+
+    it('never clubs synthetic channel_* ids (no tvg-id)', () => {
+      const out = clubByChannelId([
+        { channelId: 'channel_1', channelName: 'X', channelUrl: 'http://a' },
+        { channelId: 'channel_2', channelName: 'X', channelUrl: 'http://b' },
+      ]);
+      expect(out).toHaveLength(2);
+    });
+
+    it('does not duplicate an identical alternate URL', () => {
+      const out = clubByChannelId([
+        { channelId: 'BBC.uk', channelUrl: 'http://a' },
+        { channelId: 'BBC.uk', channelUrl: 'http://a' },
+      ]);
+      expect(out).toHaveLength(1);
+      expect(out[0].alternateStreams || []).toHaveLength(0);
+    });
+  });
+
+  describe('resolveChannelGroups', () => {
+    it('categorizes Uncategorized channels by iptv-org id then name (case-insensitive)', async () => {
+      await IptvOrgChannel.create({
+        channelId: 'BBCNews.uk',
+        channelName: 'BBC News',
+        streamUrl: 'http://s',
+        categories: ['news'],
+      });
+      const chans = [
+        { channelId: 'BBCNews.uk', channelName: 'BBC News', channelGroup: 'Uncategorized' },
+        { channelId: 'channel_9', channelName: 'bbc news', channelGroup: 'Uncategorized' },
+        { channelId: 'x', channelName: 'Unknown Chan', channelGroup: 'Uncategorized' },
+      ];
+      const resolved = await resolveChannelGroups(chans);
+      expect(resolved).toBe(2);
+      expect(chans[0].channelGroup).toBe('news'); // matched by id
+      expect(chans[1].channelGroup).toBe('news'); // matched by normalized name
+      expect(chans[2].channelGroup).toBe('Uncategorized'); // no match — left as-is
+    });
+
+    it('does not overwrite a group that was already set', async () => {
+      await IptvOrgChannel.create({
+        channelId: 'A.uk',
+        channelName: 'A',
+        streamUrl: 'http://s',
+        categories: ['news'],
+      });
+      const chans = [{ channelId: 'A.uk', channelName: 'A', channelGroup: 'Sports' }];
+      await resolveChannelGroups(chans);
+      expect(chans[0].channelGroup).toBe('Sports');
+    });
+  });
+
+  describe('extractExtinfTitle', () => {
+    it('handles commas inside tvg-logo URLs (Cloudinary transforms)', () => {
+      const line =
+        '#EXTINF:-1 tvg-id="ts1444" tvg-logo="https://res.cloudinary.com/x/image/fetch/fl_lossy,q_auto,h_250,w_250/https://cdn.example.com/TPMARCLS_Thumbnail.png",Tata Play Marathi Classics';
+      expect(extractExtinfTitle(line)).toBe('Tata Play Marathi Classics');
+    });
+
+    it('handles commas inside user-agent attributes', () => {
+      const line =
+        '#EXTINF:-1 tvg-id="24TV.tr" http-user-agent="Mozilla/5.0 (KHTML, like Gecko) Chrome/76.0" group-title="News",24 TV (1080p)';
+      expect(extractExtinfTitle(line)).toBe('24 TV (1080p)');
+    });
+
+    it('handles plain lines without attributes', () => {
+      expect(extractExtinfTitle('#EXTINF:-1,Simple Channel')).toBe('Simple Channel');
+    });
+
+    it('keeps commas that are part of the actual title', () => {
+      expect(extractExtinfTitle('#EXTINF:-1 tvg-id="x",News, Weather & Sports')).toBe(
+        'News, Weather & Sports',
+      );
+    });
+
+    it('returns empty string when no title separator exists', () => {
+      expect(extractExtinfTitle('#EXTINF:-1 tvg-id="x"')).toBe('');
+    });
+  });
+
+  describe('patternCategory', () => {
+    it.each([
+      ['Enlightened S01 E09', 'series'],
+      ['Bored to Death S02E06', 'series'],
+      ['Camp Crasher (2024)', 'movies'],
+      ['Warten auf Bojangles (2021)', 'movies'],
+      ['DE: Sky Bundesliga 7 FHD', 'sports'], // keyword beats prefix
+      ['USA: FOX NEWS CHANNEL', 'news'],
+      ['FR: USHUAIA TV', 'FR'], // no keyword → country prefix
+      ['CL: TVO Tocopilla', 'CL'],
+      ['MT: Smash Movies', 'movies'],
+      ['Some Random Channel', null], // unsure → null, stays Uncategorized
+      ['', null],
+    ])('%s → %s', (name, expected) => {
+      expect(patternCategory(name)).toBe(expected);
+    });
+  });
+
+  describe('capChannelAdditions', () => {
+    afterEach(() => {
+      delete process.env.USER_CHANNELS_MAX;
+    });
+
+    it('allows everything when under the limit', () => {
+      process.env.USER_CHANNELS_MAX = '10';
+      expect(capChannelAdditions(3, ['a', 'b'])).toEqual({ allowed: ['a', 'b'], rejected: 0 });
+    });
+
+    it('trims additions to the remaining room', () => {
+      process.env.USER_CHANNELS_MAX = '5';
+      expect(capChannelAdditions(4, ['a', 'b', 'c'])).toEqual({ allowed: ['a'], rejected: 2 });
+    });
+
+    it('rejects all additions for an over-limit legacy user (but never throws)', () => {
+      process.env.USER_CHANNELS_MAX = '5';
+      expect(capChannelAdditions(19898, ['a'])).toEqual({ allowed: [], rejected: 1 });
+    });
+  });
+
+  describe('dedupAgainstCatalog', () => {
+    it('drops URLs already in the catalog and within-batch duplicates', async () => {
+      await Channel.create({
+        channelId: 'existing',
+        channelName: 'E',
+        channelUrl: 'http://dup',
+        ownerId: null,
+      });
+      const out = await dedupAgainstCatalog([
+        { channelId: 'a', channelName: 'A', channelUrl: 'http://dup' }, // already in catalog
+        { channelId: 'b', channelName: 'B', channelUrl: 'http://new' }, // new
+        { channelId: 'c', channelName: 'C', channelUrl: 'http://new' }, // within-batch dupe
+      ]);
+      expect(out.map((c) => c.channelUrl)).toEqual(['http://new']);
+    });
+  });
+});

--- a/backend/src/middleware/requireTvOrSessionAuth.ts
+++ b/backend/src/middleware/requireTvOrSessionAuth.ts
@@ -18,7 +18,9 @@ const requireTvOrSessionAuth = async (req: Request, res: Response, next: NextFun
       const user = (await User.findOne({
         channelListCode: tvCode.toUpperCase(),
         isActive: true,
-      })) as any;
+      }).select(
+        'username email role channels channelListCode isActive emailVerified allCatalog',
+      )) as any;
 
       if (user) {
         req.user = {
@@ -30,6 +32,7 @@ const requireTvOrSessionAuth = async (req: Request, res: Response, next: NextFun
           channelListCode: user.channelListCode,
           isActive: user.isActive,
           emailVerified: user.emailVerified ?? false,
+          allCatalog: user.allCatalog === true,
         };
         return next();
       }
@@ -49,7 +52,10 @@ const requireTvOrSessionAuth = async (req: Request, res: Response, next: NextFun
       });
     }
 
-    const session = await Session.findOne({ sessionId }).populate('userId');
+    const session = await Session.findOne({ sessionId }).populate(
+      'userId',
+      'username email role channels channelListCode isActive emailVerified allCatalog',
+    );
 
     if (!session) {
       return res.status(401).json({
@@ -86,6 +92,7 @@ const requireTvOrSessionAuth = async (req: Request, res: Response, next: NextFun
       channelListCode: user.channelListCode,
       isActive: user.isActive,
       emailVerified: user.emailVerified,
+      allCatalog: user.allCatalog === true,
     };
     req.sessionId = sessionId;
 

--- a/backend/src/models/AuditLog.ts
+++ b/backend/src/models/AuditLog.ts
@@ -6,7 +6,7 @@ const auditLogSchema = new Schema<IAuditLogDocument>({
     type: Schema.Types.ObjectId,
     ref: 'User',
     required: true,
-    index: true,
+    // Covered by the { userId, timestamp } compound below — no standalone index.
   },
   action: {
     type: String,
@@ -16,7 +16,7 @@ const auditLogSchema = new Schema<IAuditLogDocument>({
   resource: {
     type: String,
     required: true,
-    index: true,
+    // Covered by the { resource, timestamp } compound below — no standalone index.
   },
   resourceId: {
     type: String,
@@ -42,7 +42,9 @@ const auditLogSchema = new Schema<IAuditLogDocument>({
   timestamp: {
     type: Date,
     default: Date.now,
-    index: true,
+    // Indexed ONLY via the TTL schema.index() below. A field-level `index: true` here would
+    // declare a plain timestamp_1 that blocks the TTL index from ever building (same name,
+    // different options) — which is exactly why retention never worked in production.
   },
 });
 
@@ -50,8 +52,8 @@ const auditLogSchema = new Schema<IAuditLogDocument>({
 auditLogSchema.index({ userId: 1, timestamp: -1 });
 auditLogSchema.index({ resource: 1, timestamp: -1 });
 
-// TTL index: retain audit history for 1 year, then auto-delete (prevents unbounded growth)
-auditLogSchema.index({ timestamp: 1 }, { expireAfterSeconds: 60 * 60 * 24 * 365 });
+// TTL index: retain audit history for 180 days, then auto-delete (prevents unbounded growth)
+auditLogSchema.index({ timestamp: 1 }, { expireAfterSeconds: 60 * 60 * 24 * 180 });
 
 const AuditLog = mongoose.model<IAuditLogDocument>('AuditLog', auditLogSchema);
 

--- a/backend/src/models/Channel.ts
+++ b/backend/src/models/Channel.ts
@@ -33,7 +33,7 @@ const channelSchema = new Schema<IChannelDocument>(
     channelGroup: {
       type: String,
       default: 'Uncategorized',
-      index: true,
+      // Covered by the compound { channelGroup: 1, order: 1 } index below — no standalone index.
     },
     channelDrmKey: {
       type: String,
@@ -136,33 +136,54 @@ channelSchema.index({ channelName: 'text' });
 // users can import the same channelId as their own private channels.
 channelSchema.index({ ownerId: 1, channelId: 1 }, { unique: true });
 
-// Method to convert to M3U format entry
-channelSchema.methods.toM3U = function (this: IChannelDocument): string {
+// Build a single M3U #EXTINF entry from a channel-like object.
+// Works for both Mongoose docs and lean POJOs so the playlist export can stream lean docs.
+function buildM3ULine(ch: {
+  channelId?: string;
+  tvgName?: string;
+  channelName: string;
+  tvgLogo?: string;
+  channelImg?: string;
+  channelGroup?: string;
+  channelUrl: string;
+}): string {
   // Escape double quotes in interpolated values to prevent M3U attribute injection
-  const esc = (s: string) => s.replace(/"/g, "'");
+  const esc = (s: string | undefined) => (s ?? '').replace(/"/g, "'");
 
   let m3uLine = `#EXTINF:-1`;
 
-  if (this.channelId) m3uLine += ` tvg-id="${esc(this.channelId)}"`;
-  if (this.tvgName || this.channelName)
-    m3uLine += ` tvg-name="${esc(this.tvgName || this.channelName)}"`;
-  if (this.tvgLogo || this.channelImg)
-    m3uLine += ` tvg-logo="${esc(this.tvgLogo || this.channelImg)}"`;
-  if (this.channelGroup) m3uLine += ` group-title="${esc(this.channelGroup)}"`;
+  if (ch.channelId) m3uLine += ` tvg-id="${esc(ch.channelId)}"`;
+  if (ch.tvgName || ch.channelName) m3uLine += ` tvg-name="${esc(ch.tvgName || ch.channelName)}"`;
+  if (ch.tvgLogo || ch.channelImg) m3uLine += ` tvg-logo="${esc(ch.tvgLogo || ch.channelImg)}"`;
+  if (ch.channelGroup) m3uLine += ` group-title="${esc(ch.channelGroup)}"`;
 
-  m3uLine += `,${this.channelName}\n${this.channelUrl}`;
+  m3uLine += `,${ch.channelName}\n${ch.channelUrl}`;
 
   return m3uLine;
+}
+
+// Method to convert to M3U format entry
+channelSchema.methods.toM3U = function (this: IChannelDocument): string {
+  return buildM3ULine(this);
 };
 
-// Static method to generate full M3U playlist
+// Static method to generate full M3U playlist.
+// Streams via a lean cursor + field projection so we never hydrate tens of thousands
+// of full Mongoose documents into memory at once.
 channelSchema.statics.generateM3UPlaylist = async function (): Promise<string> {
-  // The global M3U export serves the shared catalog only, never users' private channels.
-  const channels = await this.find({ ownerId: null }).sort({ channelGroup: 1, order: 1 });
+  const cursor = this.find({ ownerId: null })
+    .select(
+      'channelId channelName channelUrl channelImg tvgLogo tvgName channelGroup ' +
+        'metadata.isWorking flaggedBad.isFlagged ' +
+        'alternateStreams.streamUrl alternateStreams.liveness.status alternateStreams.flaggedBad.isFlagged',
+    )
+    .sort({ channelGroup: 1, order: 1 })
+    .lean()
+    .cursor();
 
   let m3uContent = '#EXTM3U\n\n';
 
-  channels.forEach((channel: IChannelDocument) => {
+  for (let channel: any = await cursor.next(); channel != null; channel = await cursor.next()) {
     const primaryDead = channel.metadata?.isWorking === false;
     const primaryFlagged = channel.flaggedBad?.isFlagged === true;
 
@@ -172,15 +193,12 @@ channelSchema.statics.generateM3UPlaylist = async function (): Promise<string> {
           alt.liveness?.status === 'alive' && alt.flaggedBad?.isFlagged !== true,
       );
       if (viableAlt) {
-        const originalUrl = channel.channelUrl;
-        channel.channelUrl = viableAlt.streamUrl;
-        m3uContent += channel.toM3U() + '\n\n';
-        channel.channelUrl = originalUrl;
-        return;
+        m3uContent += buildM3ULine({ ...channel, channelUrl: viableAlt.streamUrl }) + '\n\n';
+        continue;
       }
     }
-    m3uContent += channel.toM3U() + '\n\n';
-  });
+    m3uContent += buildM3ULine(channel) + '\n\n';
+  }
 
   return m3uContent;
 };

--- a/backend/src/models/IptvOrgCache.ts
+++ b/backend/src/models/IptvOrgCache.ts
@@ -64,14 +64,16 @@ const livenessSchema = new Schema(
 
 const iptvOrgChannelSchema = new Schema<IIptvOrgChannelDocument>(
   {
-    channelId: { type: String, required: true, index: true },
+    // channelId is covered by the unique compound { channelId: 1, streamUrl: 1 } below.
+    channelId: { type: String, required: true },
     channelName: { type: String, required: true },
     streamUrl: { type: String, required: true },
     streamQuality: { type: String, default: null },
     streamUserAgent: { type: String, default: null },
     streamReferrer: { type: String, default: null },
     tvgLogo: { type: String, default: null },
-    country: { type: String, default: null, index: true },
+    // country is covered by the compound country_1_* indexes below.
+    country: { type: String, default: null },
     categories: { type: [String], default: [], index: true },
     languageCodes: { type: [String], default: [], index: true },
     languageNames: { type: [String], default: [] },

--- a/backend/src/models/ScheduledTaskRun.ts
+++ b/backend/src/models/ScheduledTaskRun.ts
@@ -19,7 +19,9 @@ const subtaskSchema = new Schema(
 
 const scheduledTaskRunSchema = new Schema(
   {
-    taskName: { type: String, required: true, index: true },
+    // No field-level index — it would declare a plain taskName_1 that blocks the
+    // partial-unique lock index below (same name, different options) from building.
+    taskName: { type: String, required: true },
     status: {
       type: String,
       enum: ['pending', 'running', 'completed', 'failed'],
@@ -56,6 +58,8 @@ scheduledTaskRunSchema.index(
   { taskName: 1 },
   { unique: true, partialFilterExpression: { status: 'running' } },
 );
+// TTL: retain task-run history 30 days, then auto-delete (prevents unbounded growth)
+scheduledTaskRunSchema.index({ createdAt: 1 }, { expireAfterSeconds: 30 * 24 * 60 * 60 });
 
 export const ScheduledTaskRun = mongoose.model('ScheduledTaskRun', scheduledTaskRunSchema);
 

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -60,6 +60,12 @@ const userSchema = new Schema<IUserDocument>(
         ref: 'Channel',
       },
     ],
+    // Serve the whole shared catalog (capped at TV_CHANNELS_MAX) instead of channels[] —
+    // for "wants everything" users; avoids a giant $in and an unbounded channels array.
+    allCatalog: {
+      type: Boolean,
+      default: false,
+    },
     lastLogin: {
       type: Date,
     },

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -12,6 +12,22 @@ const { validateUrlForSSRF } = require('../utils/ssrf-guard');
 const AuditLog = require('../models/AuditLog');
 const { ExternalSourceChannel } = require('../models/ExternalSourceCache');
 const { ScheduledTaskRun } = require('../models/ScheduledTaskRun');
+const { channelCache, statsCache } = require('../services/cache');
+const {
+  resolveChannelGroups,
+  clubByChannelId,
+  dedupAgainstCatalog,
+  extractExtinfTitle,
+} = require('../services/import-helpers');
+
+// Bust the cached admin/demo catalog (served by GET /channels + /grouped) on any catalog
+// mutation, and drop cached channel-list counts. Keeps the TV/demo view consistent after edits.
+function invalidateCatalogCache() {
+  return Promise.all([
+    channelCache.deletePattern('catalog:*'),
+    statsCache.deletePattern('chcount:*'),
+  ]);
+}
 
 // Apply session authentication and admin role check to all admin routes
 router.use(requireAuth);
@@ -51,6 +67,7 @@ router.post('/channels', async (req, res) => {
       metadata,
     });
     await channel.save();
+    await invalidateCatalogCache();
     audit({
       userId: req.user.id,
       action: 'create_channel',
@@ -139,6 +156,7 @@ router.put('/channels/:id', async (req, res) => {
       });
     }
 
+    await invalidateCatalogCache();
     audit({
       userId: req.user.id,
       action: 'update_channel',
@@ -177,6 +195,7 @@ router.delete('/channels/:id', async (req, res) => {
     // Remove the deleted channel id from every user's channels array to avoid orphan refs
     await User.updateMany({ channels: req.params.id }, { $pull: { channels: req.params.id } });
 
+    await invalidateCatalogCache();
     audit({
       userId: req.user.id,
       action: 'delete_channel',
@@ -221,6 +240,7 @@ router.delete('/channels', async (req, res) => {
       );
     }
 
+    await invalidateCatalogCache();
     audit({
       userId: req.user.id,
       action: 'delete_all_channels',
@@ -298,7 +318,9 @@ router.post('/channels/import-m3u', async (req, res) => {
         const tvgNameMatch = line.match(/tvg-name="([^"]*)"/);
         const tvgLogoMatch = line.match(/tvg-logo="([^"]*)"/);
         const groupTitleMatch = line.match(/group-title="([^"]*)"/);
-        const channelNameMatch = line.match(/,(.+)$/);
+        // Title = text after the attribute list, NOT after the first comma — attribute
+        // values (logo URLs, user-agents) legally contain commas.
+        const channelName = extractExtinfTitle(line);
 
         currentChannel = {
           channelId: tvgIdMatch ? tvgIdMatch[1] : `channel_${Date.now()}_${i}`,
@@ -306,7 +328,7 @@ router.post('/channels/import-m3u', async (req, res) => {
           channelImg: tvgLogoMatch ? tvgLogoMatch[1] : '',
           tvgLogo: tvgLogoMatch ? tvgLogoMatch[1] : '',
           channelGroup: groupTitleMatch ? groupTitleMatch[1] : 'Uncategorized',
-          channelName: channelNameMatch ? channelNameMatch[1].trim() : 'Unknown',
+          channelName: channelName || 'Unknown',
           order: channels.length,
         };
       } else if (line && !line.startsWith('#') && currentChannel) {
@@ -329,9 +351,19 @@ router.post('/channels/import-m3u', async (req, res) => {
       });
     }
 
-    // Insert only SSRF-safe channels into database
-    const insertedChannels = await Channel.insertMany(safeChannels, { ordered: false });
+    // Club same-tvg-id entries into alternateStreams, categorize from the iptv-org cache so the
+    // catalog isn't dumped into 'Uncategorized', then drop URLs already in the catalog so a
+    // re-import doesn't create duplicate rows.
+    const clubbed = clubByChannelId(safeChannels);
+    await resolveChannelGroups(clubbed);
+    const toInsert = await dedupAgainstCatalog(clubbed);
 
+    // Insert only SSRF-safe, non-duplicate channels into database
+    const insertedChannels = toInsert.length
+      ? await Channel.insertMany(toInsert, { ordered: false })
+      : [];
+
+    await invalidateCatalogCache();
     audit({
       userId: req.user.id,
       action: 'import_m3u',
@@ -341,9 +373,13 @@ router.post('/channels/import-m3u', async (req, res) => {
       userAgent: req.headers['user-agent'],
     });
 
+    const duplicateCount = clubbed.length - toInsert.length;
+    const notes = [];
+    if (blockedCount > 0) notes.push(`${blockedCount} blocked by security policy`);
+    if (duplicateCount > 0) notes.push(`${duplicateCount} already in catalog`);
     const message =
-      blockedCount > 0
-        ? `Imported ${insertedChannels.length} channels (${blockedCount} blocked by security policy)`
+      notes.length > 0
+        ? `Imported ${insertedChannels.length} channels (${notes.join(', ')})`
         : `Successfully imported ${insertedChannels.length} channels`;
 
     res.json({
@@ -351,6 +387,7 @@ router.post('/channels/import-m3u', async (req, res) => {
       message,
       count: insertedChannels.length,
       blockedCount,
+      duplicateCount,
     });
   } catch (error) {
     console.error('Error importing M3U:', error);
@@ -489,18 +526,48 @@ router.get('/channels', async (req, res) => {
     const p = parseInt(page, 10) || 1;
     const ps = Math.min(parseInt(pageSize, 10) || 50, 200);
 
-    const [channels, totalCount] = await Promise.all([
+    // countDocuments on the catalog is expensive and identical across pages of the same
+    // filter — cache it (short TTL, busted on catalog mutations) and run it alongside the find.
+    const filterKey = JSON.stringify({ group, status, language, country, search });
+    const countKey = `chcount:${filterKey}`;
+    const healthKey = `chcount:health:${filterKey}`;
+
+    const [channels, totalCount, health] = await Promise.all([
       Channel.find(filter)
         .sort({ channelGroup: 1, order: 1 })
         .skip((p - 1) * ps)
-        .limit(ps),
-      Channel.countDocuments(filter),
+        .limit(ps)
+        .lean(),
+      (async () => {
+        const cached = await statsCache.get(countKey);
+        if (typeof cached === 'number') return cached;
+        const fresh = await Channel.countDocuments(filter);
+        await statsCache.set(countKey, fresh);
+        return fresh;
+      })(),
+      (async () => {
+        const cached = await statsCache.get(healthKey);
+        if (cached) return cached;
+        const agg = await Channel.aggregate([
+          { $match: filter },
+          { $group: { _id: '$metadata.isWorking', n: { $sum: 1 } } },
+        ]);
+        const fresh = { working: 0, notWorking: 0, untested: 0 };
+        for (const row of agg) {
+          if (row._id === true) fresh.working += row.n;
+          else if (row._id === false) fresh.notWorking += row.n;
+          else fresh.untested += row.n;
+        }
+        await statsCache.set(healthKey, fresh);
+        return fresh;
+      })(),
     ]);
 
     res.json({
       success: true,
       count: channels.length,
       totalCount,
+      health,
       page: p,
       pageSize: ps,
       data: channels,

--- a/backend/src/routes/channel-test.js
+++ b/backend/src/routes/channel-test.js
@@ -8,7 +8,16 @@ const http = require('http');
 const https = require('https');
 const { validateUrlForSSRF, isPrivateIP, createPinnedLookup } = require('../utils/ssrf-guard');
 const { audit } = require('../services/audit-log');
-const { statsCache } = require('../services/cache');
+const { statsCache, channelCache } = require('../services/cache');
+
+// Tests update metadata.isWorking, which the cached catalog payload includes —
+// bust the cached counts AND the catalog after test results land.
+function invalidateChannelCaches() {
+  return Promise.all([
+    statsCache.deletePattern('chcount:*'),
+    channelCache.deletePattern('catalog:*'),
+  ]);
+}
 
 // Apply authentication to all routes — admin only for testing operations
 router.use(requireAuth);
@@ -95,7 +104,7 @@ router.post('/test-channel', async (req, res) => {
       'metadata.isWorking': result.working,
       'metadata.responseTime': result.responseTime,
     });
-    await statsCache.deletePattern('chcount:*');
+    await invalidateChannelCaches();
     audit({
       userId: req.user.id,
       action: 'test_channel',
@@ -187,7 +196,7 @@ router.post('/test-batch', async (req, res) => {
         }
       }
 
-      await statsCache.deletePattern('chcount:*');
+      await invalidateChannelCaches();
       audit({
         userId: req.user.id,
         action: 'test_channel_batch',
@@ -271,7 +280,7 @@ router.post('/test-all', async (req, res) => {
       }
 
       const workingCount = results.filter((r) => r.working).length;
-      await statsCache.deletePattern('chcount:*');
+      await invalidateChannelCaches();
       audit({
         userId: req.user.id,
         action: 'test_channel_all',

--- a/backend/src/routes/channel-test.js
+++ b/backend/src/routes/channel-test.js
@@ -8,6 +8,7 @@ const http = require('http');
 const https = require('https');
 const { validateUrlForSSRF, isPrivateIP, createPinnedLookup } = require('../utils/ssrf-guard');
 const { audit } = require('../services/audit-log');
+const { statsCache } = require('../services/cache');
 
 // Apply authentication to all routes — admin only for testing operations
 router.use(requireAuth);
@@ -94,6 +95,7 @@ router.post('/test-channel', async (req, res) => {
       'metadata.isWorking': result.working,
       'metadata.responseTime': result.responseTime,
     });
+    await statsCache.deletePattern('chcount:*');
     audit({
       userId: req.user.id,
       action: 'test_channel',
@@ -185,6 +187,7 @@ router.post('/test-batch', async (req, res) => {
         }
       }
 
+      await statsCache.deletePattern('chcount:*');
       audit({
         userId: req.user.id,
         action: 'test_channel_batch',
@@ -268,6 +271,7 @@ router.post('/test-all', async (req, res) => {
       }
 
       const workingCount = results.filter((r) => r.working).length;
+      await statsCache.deletePattern('chcount:*');
       audit({
         userId: req.user.id,
         action: 'test_channel_all',

--- a/backend/src/routes/channels.js
+++ b/backend/src/routes/channels.js
@@ -583,6 +583,8 @@ router.post('/:id/flag', requireAuth, async (req, res) => {
       return res.status(404).json({ success: false, error: 'Channel not found' });
     }
 
+    // flaggedBad is part of the cached catalog payload — bust it so clients see the flag.
+    await invalidateCatalogCache();
     flagLimits.set(flagKey, Date.now());
 
     audit({
@@ -622,6 +624,7 @@ router.post('/:id/unflag', requireAuth, requireAdmin, async (req, res) => {
       return res.status(404).json({ success: false, error: 'Channel not found' });
     }
 
+    await invalidateCatalogCache();
     audit({
       userId: req.user.id,
       action: 'unflag_channel',
@@ -673,6 +676,7 @@ router.post('/:id/alternates/:index/flag', requireAuth, async (req, res) => {
     };
     await channel.save();
 
+    await invalidateCatalogCache();
     flagLimits.set(flagKey, Date.now());
 
     audit({
@@ -714,6 +718,7 @@ router.post('/:id/alternates/:index/unflag', requireAuth, requireAdmin, async (r
     };
     await channel.save();
 
+    await invalidateCatalogCache();
     audit({
       userId: req.user.id,
       action: 'unflag_alternate_stream',

--- a/backend/src/routes/channels.js
+++ b/backend/src/routes/channels.js
@@ -8,6 +8,14 @@ const { requireTvOrSessionAuth } = require('../middleware/requireTvOrSessionAuth
 const { escapeRegex } = require('../utils/escapeRegex');
 const { validateUrlForSSRF, isPrivateIP, createPinnedLookup } = require('../utils/ssrf-guard');
 const { audit } = require('../services/audit-log');
+const { channelCache } = require('../services/cache');
+
+// The shared admin/demo catalog is identical for every admin hit and is the heaviest
+// read. Cache it (10 min TTL via channelCache) and bust it on any catalog mutation.
+// Per-user lists are NOT cached here — they change through many assignment paths.
+function invalidateCatalogCache() {
+  return channelCache.deletePattern('catalog:*');
+}
 
 // Max channels the TV app receives in one sync. An Admin's "channel list" is the
 // entire global catalog (can be tens of thousands) — no TV client can browse that,
@@ -57,27 +65,55 @@ function slimAlternates(channel) {
   return channel;
 }
 
+// Whitelist projection for the list endpoints (/, /grouped, /search) — verified against what
+// the Android app deserializes and the web frontend reads from THESE endpoints. Drops metrics,
+// timestamps, ownerId, DRM key, unused metadata and heavy alternate subfields (~40% smaller).
+// Single-channel endpoints (/:id, /:id/with-fallbacks) still return the full document.
+const CHANNEL_LIST_FIELDS = [
+  'channelId channelName channelUrl channelImg tvgLogo tvgName tvgId channelGroup',
+  'channelDrmType order isActive',
+  'metadata.country metadata.language metadata.quality',
+  'metadata.isWorking metadata.lastTested metadata.responseTime',
+  'flaggedBad.isFlagged flaggedBad.reason',
+  'alternateStreams.streamUrl alternateStreams.quality',
+  'alternateStreams.liveness.status alternateStreams.liveness.responseTimeMs',
+  'alternateStreams.liveness.lastCheckedAt',
+  'alternateStreams.flaggedBad.isFlagged alternateStreams.flaggedBad.reason',
+].join(' ');
+
 // Get channels (for Android app sync) — accepts TV code or session auth, excludes DRM keys
 router.get('/', requireTvOrSessionAuth, async (req, res) => {
   try {
-    const isAdmin = req.user.role === 'Admin';
-    // Admin/demo see the shared catalog only (ownerId:null); a user sees their own selection.
-    const query = isAdmin
+    // allCatalog users are served the shared catalog like admins — avoids a giant $in.
+    const catalogView = req.user.role === 'Admin' || req.user.allCatalog === true;
+
+    // The catalog payload is identical across requests — serve from cache when present.
+    if (catalogView) {
+      const cached = await channelCache.get('catalog:list');
+      if (cached) return res.json(cached);
+    }
+
+    // Catalog view sees the shared catalog only (ownerId:null); a user sees their own selection.
+    const query = catalogView
       ? { ownerId: null }
       : { _id: { $in: (req.user.channels || []).filter(Boolean) }, isActive: { $ne: false } };
 
     const channels = await Channel.find(query)
       .sort({ channelGroup: 1, order: 1 })
-      // Bound the admin/demo firehose; a user's own selection is returned in full.
-      .limit(isAdmin ? TV_CHANNELS_MAX : 0)
-      .select('-__v -createdAt -updatedAt -channelDrmKey')
+      // Bound every response — large payloads crash low-end TV sticks.
+      .limit(TV_CHANNELS_MAX)
+      .select(CHANNEL_LIST_FIELDS)
       .lean();
 
-    res.json({
+    const payload = {
       success: true,
       count: channels.length,
       data: channels.map(slimAlternates),
-    });
+    };
+
+    if (catalogView) await channelCache.set('catalog:list', payload);
+
+    res.json(payload);
   } catch (error) {
     console.error('Error fetching channels:', error);
     res.status(500).json({
@@ -90,33 +126,43 @@ router.get('/', requireTvOrSessionAuth, async (req, res) => {
 // Get channels grouped by category
 router.get('/grouped', requireTvOrSessionAuth, async (req, res) => {
   try {
-    const isAdmin = req.user.role === 'Admin';
-    // Admin/demo see the shared catalog only (ownerId:null); a user sees their own selection.
-    const query = isAdmin
+    const catalogView = req.user.role === 'Admin' || req.user.allCatalog === true;
+
+    if (catalogView) {
+      const cached = await channelCache.get('catalog:grouped');
+      if (cached) return res.json(cached);
+    }
+
+    // Catalog view sees the shared catalog only (ownerId:null); a user sees their own selection.
+    const query = catalogView
       ? { ownerId: null }
       : { _id: { $in: (req.user.channels || []).filter(Boolean) }, isActive: { $ne: false } };
 
     const channels = await Channel.find(query)
       .sort({ channelGroup: 1, order: 1 })
-      // Bound the admin/demo firehose; a user's own selection is returned in full.
-      .limit(isAdmin ? TV_CHANNELS_MAX : 0)
-      .select('-channelDrmKey')
+      // Bound every response — large payloads crash low-end TV sticks.
+      .limit(TV_CHANNELS_MAX)
+      .select(CHANNEL_LIST_FIELDS)
       .lean();
 
-    // Group by channelGroup
+    // Group by channelGroup (dead/flagged alternates slimmed, same as /)
     const grouped = channels.reduce((acc, channel) => {
       const group = channel.channelGroup || 'Uncategorized';
       if (!acc[group]) {
         acc[group] = [];
       }
-      acc[group].push(channel);
+      acc[group].push(slimAlternates(channel));
       return acc;
     }, {});
 
-    res.json({
+    const payload = {
       success: true,
       data: grouped,
-    });
+    };
+
+    if (catalogView) await channelCache.set('catalog:grouped', payload);
+
+    res.json(payload);
   } catch (error) {
     console.error('Error fetching grouped channels:', error);
     res.status(500).json({
@@ -148,7 +194,12 @@ router.get('/playlist.m3u', async (req, res) => {
       return res.status(403).json({ success: false, error: 'Invalid playlist code' });
     }
 
-    const m3uContent = await Channel.generateM3UPlaylist();
+    // Rendered playlist is identical for every caller — cache it (busted with catalog:* on mutations).
+    let m3uContent = await channelCache.get('catalog:m3u');
+    if (!m3uContent) {
+      m3uContent = await Channel.generateM3UPlaylist();
+      await channelCache.set('catalog:m3u', m3uContent);
+    }
     res.setHeader('Content-Type', 'application/x-mpegurl');
     res.setHeader('Content-Disposition', 'attachment; filename="playlist.m3u"');
     res.send(m3uContent);
@@ -181,17 +232,18 @@ router.get('/search', requireTvOrSessionAuth, async (req, res) => {
       ],
     };
 
-    if (req.user.role !== 'Admin') {
+    if (req.user.role !== 'Admin' && req.user.allCatalog !== true) {
       searchFilter._id = { $in: (req.user.channels || []).filter(Boolean) };
       searchFilter.isActive = { $ne: false };
     } else {
-      // Admin/demo search the shared catalog only, never users' private channels.
+      // Admin/demo/allCatalog search the shared catalog only, never users' private channels.
       searchFilter.ownerId = null;
     }
 
     const channels = await Channel.find(searchFilter)
       .sort({ channelGroup: 1, order: 1 })
-      .select('-__v -createdAt -updatedAt -channelDrmKey')
+      .limit(TV_CHANNELS_MAX)
+      .select(CHANNEL_LIST_FIELDS)
       .lean();
 
     res.json({ success: true, count: channels.length, data: channels.map(slimAlternates) });
@@ -362,6 +414,7 @@ router.post('/', requireAuth, requireAdmin, async (req, res) => {
       alternateStreams,
     });
     await channel.save();
+    await invalidateCatalogCache();
     audit({
       userId: req.user.id,
       action: 'create_channel',
@@ -424,6 +477,7 @@ router.put('/:id', requireAuth, requireAdmin, async (req, res) => {
     if (!channel) {
       return res.status(404).json({ success: false, error: 'Channel not found' });
     }
+    await invalidateCatalogCache();
     audit({
       userId: req.user.id,
       action: 'update_channel',
@@ -448,6 +502,7 @@ router.delete('/:id', requireAuth, requireAdmin, async (req, res) => {
     }
     // Remove the deleted channel id from every user's channels array to avoid orphan refs
     await User.updateMany({ channels: req.params.id }, { $pull: { channels: req.params.id } });
+    await invalidateCatalogCache();
     audit({
       userId: req.user.id,
       action: 'delete_channel',

--- a/backend/src/routes/external-sources.js
+++ b/backend/src/routes/external-sources.js
@@ -6,7 +6,7 @@ const { SeedChannel } = require('../models/SeedChannel');
 const { requireAuth, requireAdmin } = require('./auth');
 const { externalSourceCacheService } = require('../services/external-source-cache');
 const { audit } = require('../services/audit-log');
-const { capChannelAdditions } = require('../services/import-helpers');
+const { capChannelAdditions, withChannelCapFilter } = require('../services/import-helpers');
 
 const VALID_SOURCES = ['pluto-tv', 'samsung-tv-plus', 'youtube-live', 'prasar-bharati'];
 const SEED_SOURCES = ['youtube-live', 'prasar-bharati'];
@@ -607,13 +607,17 @@ router.post('/import-user', async (req, res) => {
     if (channelIdsToAdd.length > 0) {
       const { allowed, rejected } = capChannelAdditions(user.channels.length, channelIdsToAdd);
       if (allowed.length > 0) {
-        // Use atomic $addToSet to prevent lost updates under concurrent requests
-        const updated = await User.findByIdAndUpdate(
-          userId,
+        // Atomic $addToSet with the cap in the filter — concurrent imports can't overshoot.
+        const updated = await User.findOneAndUpdate(
+          withChannelCapFilter(userId, allowed.length),
           { $addToSet: { channels: { $each: allowed } } },
           { new: true },
         );
-        totalChannels = updated ? updated.channels.length : totalChannels;
+        if (updated) {
+          totalChannels = updated.channels.length;
+        } else {
+          console.warn(`[ext-sources] channel list limit hit concurrently for ${userId}`);
+        }
       }
       if (rejected > 0) {
         console.warn(`[ext-sources] channel list limit reached for ${userId}: ${rejected} skipped`);

--- a/backend/src/routes/external-sources.js
+++ b/backend/src/routes/external-sources.js
@@ -6,6 +6,7 @@ const { SeedChannel } = require('../models/SeedChannel');
 const { requireAuth, requireAdmin } = require('./auth');
 const { externalSourceCacheService } = require('../services/external-source-cache');
 const { audit } = require('../services/audit-log');
+const { capChannelAdditions } = require('../services/import-helpers');
 
 const VALID_SOURCES = ['pluto-tv', 'samsung-tv-plus', 'youtube-live', 'prasar-bharati'];
 const SEED_SOURCES = ['youtube-live', 'prasar-bharati'];
@@ -604,13 +605,19 @@ router.post('/import-user', async (req, res) => {
 
     let totalChannels = user.channels.length;
     if (channelIdsToAdd.length > 0) {
-      // Use atomic $addToSet to prevent lost updates under concurrent requests
-      const updated = await User.findByIdAndUpdate(
-        userId,
-        { $addToSet: { channels: { $each: channelIdsToAdd } } },
-        { new: true },
-      );
-      totalChannels = updated ? updated.channels.length : totalChannels;
+      const { allowed, rejected } = capChannelAdditions(user.channels.length, channelIdsToAdd);
+      if (allowed.length > 0) {
+        // Use atomic $addToSet to prevent lost updates under concurrent requests
+        const updated = await User.findByIdAndUpdate(
+          userId,
+          { $addToSet: { channels: { $each: allowed } } },
+          { new: true },
+        );
+        totalChannels = updated ? updated.channels.length : totalChannels;
+      }
+      if (rejected > 0) {
+        console.warn(`[ext-sources] channel list limit reached for ${userId}: ${rejected} skipped`);
+      }
     }
 
     audit({

--- a/backend/src/routes/iptv-org.js
+++ b/backend/src/routes/iptv-org.js
@@ -928,8 +928,16 @@ router.post('/import-user', async (req, res) => {
 
     if (channelIdsToAdd.length > 0) {
       const { allowed, rejected } = capChannelAdditions(user.channels.length, channelIdsToAdd);
-      user.channels.push(...allowed);
-      await user.save();
+      if (allowed.length > 0) {
+        // Atomic $addToSet with the cap in the filter — a snapshot-then-save would let
+        // concurrent imports overshoot USER_CHANNELS_MAX.
+        const updated = await User.updateOne(withChannelCapFilter(user._id, allowed.length), {
+          $addToSet: { channels: { $each: allowed } },
+        });
+        if (updated.matchedCount === 0) {
+          console.warn(`[iptv-org] channel list limit hit concurrently for ${req.user.id}`);
+        }
+      }
       if (rejected > 0) {
         console.warn(
           `[iptv-org] channel list limit reached for ${req.user.id}: ${rejected} skipped`,

--- a/backend/src/routes/iptv-org.js
+++ b/backend/src/routes/iptv-org.js
@@ -6,6 +6,7 @@ const User = require('../models/User');
 const { requireAuth, requireAdmin } = require('./auth');
 const { iptvOrgCacheService } = require('../services/iptv-org-cache');
 const { audit } = require('../services/audit-log');
+const { capChannelAdditions } = require('../services/import-helpers');
 
 // Apply authentication to all routes
 router.use(requireAuth);
@@ -798,10 +799,13 @@ router.post('/import-grouped-user', async (req, res) => {
     }
 
     if (channelIdsToAdd.length > 0) {
-      await User.updateOne(
-        { _id: userId },
-        { $addToSet: { channels: { $each: channelIdsToAdd } } },
-      );
+      const { allowed, rejected } = capChannelAdditions(user.channels.length, channelIdsToAdd);
+      if (allowed.length > 0) {
+        await User.updateOne({ _id: userId }, { $addToSet: { channels: { $each: allowed } } });
+      }
+      if (rejected > 0) {
+        console.warn(`[iptv-org] channel list limit reached for ${userId}: ${rejected} skipped`);
+      }
     }
 
     audit({
@@ -917,8 +921,14 @@ router.post('/import-user', async (req, res) => {
     }
 
     if (channelIdsToAdd.length > 0) {
-      user.channels.push(...channelIdsToAdd);
+      const { allowed, rejected } = capChannelAdditions(user.channels.length, channelIdsToAdd);
+      user.channels.push(...allowed);
       await user.save();
+      if (rejected > 0) {
+        console.warn(
+          `[iptv-org] channel list limit reached for ${req.user.id}: ${rejected} skipped`,
+        );
+      }
     }
 
     audit({

--- a/backend/src/routes/iptv-org.js
+++ b/backend/src/routes/iptv-org.js
@@ -6,7 +6,7 @@ const User = require('../models/User');
 const { requireAuth, requireAdmin } = require('./auth');
 const { iptvOrgCacheService } = require('../services/iptv-org-cache');
 const { audit } = require('../services/audit-log');
-const { capChannelAdditions } = require('../services/import-helpers');
+const { capChannelAdditions, withChannelCapFilter } = require('../services/import-helpers');
 
 // Apply authentication to all routes
 router.use(requireAuth);
@@ -801,7 +801,13 @@ router.post('/import-grouped-user', async (req, res) => {
     if (channelIdsToAdd.length > 0) {
       const { allowed, rejected } = capChannelAdditions(user.channels.length, channelIdsToAdd);
       if (allowed.length > 0) {
-        await User.updateOne({ _id: userId }, { $addToSet: { channels: { $each: allowed } } });
+        // Cap enforced in the filter too — concurrent imports can't overshoot the limit.
+        const updated = await User.updateOne(withChannelCapFilter(userId, allowed.length), {
+          $addToSet: { channels: { $each: allowed } },
+        });
+        if (updated.matchedCount === 0) {
+          console.warn(`[iptv-org] channel list limit hit concurrently for ${userId}`);
+        }
       }
       if (rejected > 0) {
         console.warn(`[iptv-org] channel list limit reached for ${userId}: ${rejected} skipped`);

--- a/backend/src/routes/tv.js
+++ b/backend/src/routes/tv.js
@@ -2,11 +2,54 @@ const express = require('express');
 const router = express.Router();
 const User = require('../models/User');
 const Channel = require('../models/Channel');
+const EpgProgram = require('../models/EpgProgram');
 const PairingRequest = require('../models/PairingRequest');
 const { epgService } = require('../services/epg-service');
 const { audit } = require('../services/audit-log');
+const { epgCache } = require('../services/cache');
+
+// Same cap as the /channels sync — the EPG only needs to cover what the TV can list.
+const TV_CHANNELS_MAX = Number(process.env.TV_CHANNELS_MAX) || 2000;
 
 // NO authentication required for TV endpoints
+
+// Load the channels relevant to a user's EPG, projected to only the fields the guide
+// needs, and pre-intersect candidate EPG ids against the ids that actually have guide
+// data (~1.7k) — otherwise the $in carries 3 ids per channel (~100k+) for nothing.
+async function loadEpgChannelIds(user) {
+  const catalogView = user.role === 'Admin' || user.allCatalog === true;
+  const query = catalogView ? { ownerId: null } : { _id: { $in: user.channels } };
+  const channels = await Channel.find(query)
+    .sort({ channelGroup: 1, order: 1 })
+    .limit(TV_CHANNELS_MAX)
+    .select('channelId tvgId tvgName channelName tvgLogo channelImg')
+    .lean();
+
+  let knownEpgIds = await epgCache.get('known-ids');
+  if (!knownEpgIds) {
+    knownEpgIds = await EpgProgram.distinct('channelEpgId');
+    await epgCache.set('known-ids', knownEpgIds, 600);
+  }
+  const knownSet = new Set(knownEpgIds);
+
+  const epgIds = [];
+  const channelInfoMap = new Map();
+  for (const ch of channels) {
+    const ids = [ch.channelId, ch.tvgId, ch.tvgName].filter(Boolean);
+    for (const id of ids) {
+      if (!channelInfoMap.has(id)) {
+        channelInfoMap.set(id, {
+          epgId: id,
+          channelId: ch.channelId,
+          name: ch.channelName,
+          icon: ch.tvgLogo || ch.channelImg || '',
+        });
+        if (knownSet.has(id)) epgIds.push(id);
+      }
+    }
+  }
+  return { epgIds, channelInfoMap };
+}
 
 // Shared helper: validate code, find user, update lastLogin
 async function findUserByCode(code, res) {
@@ -405,35 +448,16 @@ router.get('/epg/:code', async (req, res) => {
     const user = await findUserByCode(req.params.code, res);
     if (!user) return;
 
-    // Get user's channels
-    let channels;
-    if (user.role === 'Admin') {
-      channels = await Channel.find({ ownerId: null }).sort({ channelGroup: 1, order: 1 }).lean();
-    } else {
-      channels = await Channel.find({
-        _id: { $in: user.channels },
-      })
-        .sort({ channelGroup: 1, order: 1 })
-        .lean();
+    // Rendered XMLTV is stable for the cache window (matches Cache-Control below).
+    const cacheKey = `xml:${user.channelListCode}:${hours}`;
+    const cachedXml = await epgCache.get(cacheKey);
+    if (cachedXml) {
+      res.setHeader('Content-Type', 'application/xml');
+      res.setHeader('Cache-Control', 'public, max-age=300');
+      return res.send(cachedXml);
     }
 
-    // Build EPG IDs from channel data (tvgId, channelId, tvgName)
-    const epgIds = [];
-    const channelInfoMap = new Map();
-
-    for (const ch of channels) {
-      const ids = [ch.channelId, ch.tvgId, ch.tvgName].filter(Boolean);
-      for (const id of ids) {
-        if (!channelInfoMap.has(id)) {
-          epgIds.push(id);
-          channelInfoMap.set(id, {
-            epgId: id,
-            name: ch.channelName,
-            icon: ch.tvgLogo || ch.channelImg || '',
-          });
-        }
-      }
-    }
+    const { epgIds, channelInfoMap } = await loadEpgChannelIds(user);
 
     // Query EPG programs
     const programs = await epgService.getEpgForChannels(epgIds, hours);
@@ -451,6 +475,7 @@ router.get('/epg/:code', async (req, res) => {
     }
 
     const xmltv = epgService.generateXmltv(channelInfos, programs);
+    await epgCache.set(cacheKey, xmltv);
 
     res.setHeader('Content-Type', 'application/xml');
     res.setHeader('Cache-Control', 'public, max-age=300');
@@ -471,35 +496,14 @@ router.get('/epg/:code/json', async (req, res) => {
     const user = await findUserByCode(req.params.code, res);
     if (!user) return;
 
-    // Get user's channels
-    let channels;
-    if (user.role === 'Admin') {
-      channels = await Channel.find({ ownerId: null }).sort({ channelGroup: 1, order: 1 }).lean();
-    } else {
-      channels = await Channel.find({
-        _id: { $in: user.channels },
-      })
-        .sort({ channelGroup: 1, order: 1 })
-        .lean();
+    const cacheKey = `json:${user.channelListCode}:${hours}`;
+    const cachedPayload = await epgCache.get(cacheKey);
+    if (cachedPayload) {
+      res.setHeader('Cache-Control', 'public, max-age=300');
+      return res.json(cachedPayload);
     }
 
-    // Build EPG IDs
-    const epgIds = [];
-    const channelNameMap = new Map();
-
-    for (const ch of channels) {
-      const ids = [ch.channelId, ch.tvgId, ch.tvgName].filter(Boolean);
-      for (const id of ids) {
-        if (!channelNameMap.has(id)) {
-          epgIds.push(id);
-          channelNameMap.set(id, {
-            channelId: ch.channelId,
-            channelName: ch.channelName,
-            tvgLogo: ch.tvgLogo || ch.channelImg || '',
-          });
-        }
-      }
-    }
+    const { epgIds, channelInfoMap } = await loadEpgChannelIds(user);
 
     const programs = await epgService.getEpgForChannels(epgIds, hours);
 
@@ -507,11 +511,11 @@ router.get('/epg/:code/json', async (req, res) => {
     const grouped = {};
     for (const prog of programs) {
       if (!grouped[prog.channelEpgId]) {
-        const info = channelNameMap.get(prog.channelEpgId) || {};
+        const info = channelInfoMap.get(prog.channelEpgId) || {};
         grouped[prog.channelEpgId] = {
           channelId: prog.channelEpgId,
-          channelName: info.channelName || prog.channelEpgId,
-          tvgLogo: info.tvgLogo || '',
+          channelName: info.name || prog.channelEpgId,
+          tvgLogo: info.icon || '',
           programs: [],
         };
       }
@@ -526,14 +530,17 @@ router.get('/epg/:code/json', async (req, res) => {
       });
     }
 
-    res.setHeader('Cache-Control', 'public, max-age=300');
-    res.json({
+    const payload = {
       success: true,
       hours,
       channelCount: Object.keys(grouped).length,
       programCount: programs.length,
       channels: Object.values(grouped),
-    });
+    };
+    await epgCache.set(cacheKey, payload);
+
+    res.setHeader('Cache-Control', 'public, max-age=300');
+    res.json(payload);
   } catch (error) {
     console.error('Error fetching EPG JSON:', error);
     res.status(500).json({

--- a/backend/src/routes/user-playlist.js
+++ b/backend/src/routes/user-playlist.js
@@ -5,6 +5,12 @@ const User = require('../models/User');
 const Channel = require('../models/Channel');
 const { requireAuth } = require('./auth');
 const { audit } = require('../services/audit-log');
+const {
+  resolveChannelGroups,
+  clubByChannelId,
+  capChannelAdditions,
+  extractExtinfTitle,
+} = require('../services/import-helpers');
 
 // Get current user's channels
 router.get('/me/channels', requireAuth, async (req, res) => {
@@ -98,9 +104,15 @@ router.post('/me/channels/add', requireAuth, async (req, res) => {
     }).select('_id');
     const validIds = validChannels.map((c) => c._id.toString());
 
-    const toAdd = validIds.filter((id) => !existingIds.has(id));
+    const wanted = validIds.filter((id) => !existingIds.has(id));
+    const { allowed: toAdd, rejected } = capChannelAdditions(user.channels.length, wanted);
     user.channels.push(...toAdd.map((id) => new mongoose.Types.ObjectId(id)));
     await user.save();
+    if (rejected > 0) {
+      console.warn(
+        `[user-playlist] channel list limit reached for ${req.user.id}: ${rejected} skipped`,
+      );
+    }
     audit({
       userId: req.user.id,
       action: 'add_channels',
@@ -232,7 +244,9 @@ router.post('/me/import-m3u', requireAuth, async (req, res) => {
         const tvgNameMatch = line.match(/tvg-name="([^"]*)"/);
         const tvgLogoMatch = line.match(/tvg-logo="([^"]*)"/);
         const groupTitleMatch = line.match(/group-title="([^"]*)"/);
-        const channelNameMatch = line.match(/,(.+)$/);
+        // Title = text after the attribute list, NOT after the first comma — attribute
+        // values (logo URLs, user-agents) legally contain commas.
+        const channelName = extractExtinfTitle(line);
 
         currentChannel = {
           channelId: tvgIdMatch ? tvgIdMatch[1] : `channel_${Date.now()}_${i}`,
@@ -240,7 +254,7 @@ router.post('/me/import-m3u', requireAuth, async (req, res) => {
           channelImg: tvgLogoMatch ? tvgLogoMatch[1] : '',
           tvgLogo: tvgLogoMatch ? tvgLogoMatch[1] : '',
           channelGroup: groupTitleMatch ? groupTitleMatch[1] : 'Uncategorized',
-          channelName: channelNameMatch ? channelNameMatch[1].trim() : 'Unknown',
+          channelName: channelName || 'Unknown',
           order: parsedChannels.length,
         };
       } else if (line && !line.startsWith('#') && currentChannel) {
@@ -257,9 +271,14 @@ router.post('/me/import-m3u', requireAuth, async (req, res) => {
       });
     }
 
+    // Club same-tvg-id entries into alternateStreams and categorize from the iptv-org cache
+    // so an imported list isn't dumped into 'Uncategorized'.
+    const importChannels = clubByChannelId(parsedChannels);
+    await resolveChannelGroups(importChannels);
+
     // Dedup only against THIS user's own (private) channels — never the shared catalog
     // or other users' imports.
-    const urls = parsedChannels.map((ch) => ch.channelUrl);
+    const urls = importChannels.map((ch) => ch.channelUrl);
     const existingChannels = await Channel.find({
       channelUrl: { $in: urls },
       ownerId: req.user.id,
@@ -267,7 +286,7 @@ router.post('/me/import-m3u', requireAuth, async (req, res) => {
     const existingUrlMap = new Map(existingChannels.map((ch) => [ch.channelUrl, ch._id]));
 
     // Create the rest as private channels owned by this user.
-    const toCreate = parsedChannels
+    const toCreate = importChannels
       .filter((ch) => !existingUrlMap.has(ch.channelUrl))
       .map((ch) => ({ ...ch, ownerId: req.user.id }));
     let createdChannels = [];
@@ -291,9 +310,15 @@ router.post('/me/import-m3u', requireAuth, async (req, res) => {
     if (!user) return res.status(404).json({ success: false, error: 'User not found' });
 
     const userChannelIds = new Set(user.channels.map((id) => id.toString()));
-    const toAdd = allChannelIds.filter((id) => !userChannelIds.has(id.toString()));
+    const wanted = allChannelIds.filter((id) => !userChannelIds.has(id.toString()));
+    const { allowed: toAdd, rejected } = capChannelAdditions(user.channels.length, wanted);
     user.channels.push(...toAdd.map((id) => new mongoose.Types.ObjectId(id)));
     await user.save();
+    if (rejected > 0) {
+      console.warn(
+        `[user-playlist] channel list limit reached for ${req.user.id}: ${rejected} skipped`,
+      );
+    }
 
     audit({
       userId: req.user.id,

--- a/backend/src/routes/user-playlist.js
+++ b/backend/src/routes/user-playlist.js
@@ -9,6 +9,7 @@ const {
   resolveChannelGroups,
   clubByChannelId,
   capChannelAdditions,
+  withChannelCapFilter,
   extractExtinfTitle,
 } = require('../services/import-helpers');
 
@@ -106,8 +107,23 @@ router.post('/me/channels/add', requireAuth, async (req, res) => {
 
     const wanted = validIds.filter((id) => !existingIds.has(id));
     const { allowed: toAdd, rejected } = capChannelAdditions(user.channels.length, wanted);
-    user.channels.push(...toAdd.map((id) => new mongoose.Types.ObjectId(id)));
-    await user.save();
+    let finalCount = user.channels.length;
+    let addedCount = 0;
+    if (toAdd.length > 0) {
+      // Atomic $addToSet with the cap in the filter — a snapshot-then-save would let
+      // concurrent additions overshoot USER_CHANNELS_MAX.
+      const updated = await User.findOneAndUpdate(
+        withChannelCapFilter(user._id, toAdd.length),
+        { $addToSet: { channels: { $each: toAdd.map((id) => new mongoose.Types.ObjectId(id)) } } },
+        { new: true },
+      );
+      if (updated) {
+        finalCount = updated.channels.length;
+        addedCount = toAdd.length;
+      } else {
+        console.warn(`[user-playlist] channel list limit hit concurrently for ${req.user.id}`);
+      }
+    }
     if (rejected > 0) {
       console.warn(
         `[user-playlist] channel list limit reached for ${req.user.id}: ${rejected} skipped`,
@@ -117,16 +133,16 @@ router.post('/me/channels/add', requireAuth, async (req, res) => {
       userId: req.user.id,
       action: 'add_channels',
       resource: 'user_playlist',
-      resourceId: `${toAdd.length} channels`,
+      resourceId: `${addedCount} channels`,
       ipAddress: req.ip,
       userAgent: req.headers['user-agent'],
     });
 
     res.json({
       success: true,
-      message: `Added ${toAdd.length} channels`,
-      count: user.channels.length,
-      addedCount: toAdd.length,
+      message: `Added ${addedCount} channels`,
+      count: finalCount,
+      addedCount,
     });
   } catch (error) {
     console.error('Add my channels error:', error);
@@ -312,8 +328,23 @@ router.post('/me/import-m3u', requireAuth, async (req, res) => {
     const userChannelIds = new Set(user.channels.map((id) => id.toString()));
     const wanted = allChannelIds.filter((id) => !userChannelIds.has(id.toString()));
     const { allowed: toAdd, rejected } = capChannelAdditions(user.channels.length, wanted);
-    user.channels.push(...toAdd.map((id) => new mongoose.Types.ObjectId(id)));
-    await user.save();
+    let finalCount = user.channels.length;
+    let addedCount = 0;
+    if (toAdd.length > 0) {
+      // Atomic $addToSet with the cap in the filter — a snapshot-then-save would let
+      // concurrent imports overshoot USER_CHANNELS_MAX.
+      const updated = await User.findOneAndUpdate(
+        withChannelCapFilter(user._id, toAdd.length),
+        { $addToSet: { channels: { $each: toAdd.map((id) => new mongoose.Types.ObjectId(id)) } } },
+        { new: true },
+      );
+      if (updated) {
+        finalCount = updated.channels.length;
+        addedCount = toAdd.length;
+      } else {
+        console.warn(`[user-playlist] channel list limit hit concurrently for ${req.user.id}`);
+      }
+    }
     if (rejected > 0) {
       console.warn(
         `[user-playlist] channel list limit reached for ${req.user.id}: ${rejected} skipped`,
@@ -324,16 +355,16 @@ router.post('/me/import-m3u', requireAuth, async (req, res) => {
       userId: req.user.id,
       action: 'import_m3u',
       resource: 'user_playlist',
-      resourceId: `${toAdd.length} channels`,
+      resourceId: `${addedCount} channels`,
       ipAddress: req.ip,
       userAgent: req.headers['user-agent'],
     });
 
     res.json({
       success: true,
-      message: `Added ${toAdd.length} channels to your list`,
-      added: toAdd.length,
-      count: user.channels.length,
+      message: `Added ${addedCount} channels to your list`,
+      added: addedCount,
+      count: finalCount,
     });
   } catch (error) {
     console.error('User import M3U error:', error);

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -294,7 +294,7 @@ router.put('/:id', requireAuth, async (req, res) => {
       return res.status(400).json({ success: false, error: 'Invalid user ID format' });
     }
 
-    const { username, email, password, role, isActive } = req.body;
+    const { username, email, password, role, isActive, allCatalog } = req.body;
 
     // Check if user is accessing their own profile or is admin
     const isAdmin = req.user.role === 'Admin';
@@ -343,11 +343,12 @@ router.put('/:id', requireAuth, async (req, res) => {
       user.password = password; // Will be hashed by pre-save hook
     }
 
-    // Only admin can change role and isActive
+    // Only admin can change role, isActive and allCatalog
     const previousRole = user.role;
     if (isAdmin) {
       if (role !== undefined) user.role = role;
       if (isActive !== undefined) user.isActive = isActive;
+      if (allCatalog !== undefined) user.allCatalog = allCatalog === true;
     }
 
     await user.save();

--- a/backend/src/scripts/migrations/0003-sync-indexes.ts
+++ b/backend/src/scripts/migrations/0003-sync-indexes.ts
@@ -1,0 +1,112 @@
+/**
+ * Migration 0003 — Apply the retention/index declaration changes from the DB optimization pass.
+ *
+ * The model declarations changed, but Mongoose `autoIndex` only CREATES missing
+ * indexes — it never drops or alters an existing one. On a database that predates
+ * these changes the old indexes survive until this script reconciles them:
+ *
+ *   - AuditLog          timestamp TTL 365d → 180d; drop redundant userId_1 / resource_1
+ *                       (covered by { userId, timestamp } / { resource, timestamp })
+ *   - ScheduledTaskRun  NEW createdAt TTL (30d) — history was unbounded
+ *   - Channel           drop redundant channelGroup_1 (covered by { channelGroup, order });
+ *                       also applies the 0001 index swap on catalogs that never ran it:
+ *                       drops the legacy global-unique channelId_1 and builds
+ *                       { ownerId, channelId } unique + ownerId_1 (channelId stays
+ *                       indexed non-unique). Safe while channelId values are unique.
+ *   - IptvOrgChannel    drop redundant channelId_1 (covered by { channelId, streamUrl })
+ *                       and country_1 (covered by the country_1_* compounds)
+ *
+ * Safe to re-run: syncIndexes() is a no-op once the live indexes match the schemas.
+ *
+ * Usage (from backend/):
+ *   npx tsx src/scripts/migrations/0003-sync-indexes.ts            # DRY-RUN (default) — reports only
+ *   npx tsx src/scripts/migrations/0003-sync-indexes.ts --commit   # apply changes
+ *   npm run migrate:sync-indexes -- --commit
+ *
+ * ALWAYS take a `mongodump` before running with --commit.
+ */
+import path from 'path';
+import mongoose from 'mongoose';
+
+require('dotenv').config({ path: path.resolve(__dirname, '../../../../.env') });
+
+// Importing the models registers their schemas (and current index definitions).
+import AuditLog from '../../models/AuditLog';
+import { ScheduledTaskRun } from '../../models/ScheduledTaskRun';
+import Channel from '../../models/Channel';
+import { IptvOrgChannel } from '../../models/IptvOrgCache';
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/firevision-iptv';
+const COMMIT = process.argv.includes('--commit');
+
+type IndexInfo = {
+  name: string;
+  key: Record<string, number>;
+  unique?: boolean;
+  expireAfterSeconds?: number;
+};
+
+async function listIndexes(model: mongoose.Model<any>): Promise<IndexInfo[]> {
+  try {
+    return (await model.collection.indexes()) as IndexInfo[];
+  } catch {
+    return []; // collection may not exist yet on a fresh DB
+  }
+}
+
+function describe(ix: IndexInfo[]): string {
+  return ix
+    .filter((i) => i.name !== '_id_')
+    .map((i) => {
+      const flags = [
+        i.unique && 'unique',
+        i.expireAfterSeconds !== undefined && `ttl:${i.expireAfterSeconds}s`,
+      ]
+        .filter(Boolean)
+        .join(',');
+      return `      ${i.name}${flags ? ` [${flags}]` : ''}`;
+    })
+    .join('\n');
+}
+
+async function syncModel(model: mongoose.Model<any>, label: string): Promise<void> {
+  console.log(`\n[${label}]`);
+  const before = await listIndexes(model);
+  console.log(`  Current indexes:\n${describe(before) || '      (none)'}`);
+
+  if (!COMMIT) {
+    console.log(`  (dry-run — would run syncIndexes() to match the schema)`);
+    return;
+  }
+
+  const dropped = await model.syncIndexes();
+  console.log(`  syncIndexes() dropped: ${dropped.length ? dropped.join(', ') : '(none)'}`);
+  const after = await listIndexes(model);
+  console.log(`  Resulting indexes:\n${describe(after) || '      (none)'}`);
+}
+
+async function run(): Promise<void> {
+  console.log(`\n=== Migration 0003: sync indexes (${COMMIT ? 'COMMIT' : 'DRY-RUN'}) ===`);
+  await mongoose.connect(MONGODB_URI);
+  console.log(`Connected: ${MONGODB_URI.replace(/\/\/[^@]*@/, '//***@')}`);
+
+  await syncModel(AuditLog, 'AuditLog');
+  await syncModel(ScheduledTaskRun, 'ScheduledTaskRun');
+  await syncModel(Channel, 'Channel');
+  await syncModel(IptvOrgChannel, 'IptvOrgChannel');
+
+  if (!COMMIT) {
+    console.log(`\nDry-run complete — no changes written. Re-run with --commit to apply.`);
+  } else {
+    console.log(`\nMigration complete.`);
+  }
+
+  await mongoose.connection.close();
+  console.log('Done.\n');
+}
+
+run().catch(async (err) => {
+  console.error('\nMigration error:', err);
+  await mongoose.connection.close().catch(() => {});
+  process.exit(1);
+});

--- a/backend/src/scripts/migrations/0004-categorize-backfill.ts
+++ b/backend/src/scripts/migrations/0004-categorize-backfill.ts
@@ -1,0 +1,70 @@
+/**
+ * Migration 0004 — Backfill channelGroup for 'Uncategorized' channels.
+ *
+ * Bulk M3U imports that carried no `group-title` left ~70% of the catalog in
+ * 'Uncategorized' (import-time categorization now prevents new ones). This backfill
+ * resolves a category for EXISTING rows from the iptv-org cache — matched by tvg-id
+ * first, then normalized channel name — via the same `resolveChannelGroups()` helper
+ * the import paths use. Channels with no match are left as-is.
+ *
+ * Safe to re-run: already-categorized rows no longer match the Uncategorized filter.
+ *
+ * Usage (from backend/):
+ *   npx tsx src/scripts/migrations/0004-categorize-backfill.ts            # DRY-RUN (default)
+ *   npx tsx src/scripts/migrations/0004-categorize-backfill.ts --commit   # apply changes
+ *   npm run migrate:categorize -- --commit
+ *
+ * ALWAYS take a `mongodump` before running with --commit.
+ */
+import path from 'path';
+import mongoose from 'mongoose';
+
+require('dotenv').config({ path: path.resolve(__dirname, '../../../../.env') });
+
+import Channel from '../../models/Channel';
+import { resolveChannelGroups } from '../../services/import-helpers';
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/firevision-iptv';
+const COMMIT = process.argv.includes('--commit');
+
+async function run(): Promise<void> {
+  console.log(`\n=== Migration 0004: categorize backfill (${COMMIT ? 'COMMIT' : 'DRY-RUN'}) ===`);
+  await mongoose.connect(MONGODB_URI);
+  console.log(`Connected: ${MONGODB_URI.replace(/\/\/[^@]*@/, '//***@')}`);
+
+  const docs: any[] = await Channel.find(
+    { channelGroup: 'Uncategorized' },
+    { channelId: 1, channelName: 1, channelGroup: 1 },
+  ).lean();
+  console.log(`Uncategorized channels: ${docs.length}`);
+
+  const resolved = await resolveChannelGroups(docs);
+  const changed = docs.filter((d) => d.channelGroup !== 'Uncategorized');
+  console.log(`Resolvable from iptv-org cache: ${resolved}`);
+
+  const byGroup = new Map<string, number>();
+  for (const d of changed) byGroup.set(d.channelGroup, (byGroup.get(d.channelGroup) || 0) + 1);
+  const top = [...byGroup.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
+  console.log(`Top categories: ${top.map(([g, n]) => `${g}=${n}`).join(', ') || '(none)'}`);
+
+  if (!COMMIT) {
+    console.log(`\nDry-run complete — no changes written. Re-run with --commit to apply.`);
+  } else if (changed.length) {
+    const res = await Channel.bulkWrite(
+      changed.map((d) => ({
+        updateOne: { filter: { _id: d._id }, update: { $set: { channelGroup: d.channelGroup } } },
+      })),
+      { ordered: false },
+    );
+    console.log(`\nUpdated ${res.modifiedCount} channels.`);
+  }
+
+  await mongoose.connection.close();
+  console.log('Done.\n');
+}
+
+run().catch(async (err) => {
+  console.error('\nMigration error:', err);
+  await mongoose.connection.close().catch(() => {});
+  process.exit(1);
+});

--- a/backend/src/scripts/migrations/0005-dedup-channel-urls.ts
+++ b/backend/src/scripts/migrations/0005-dedup-channel-urls.ts
@@ -10,7 +10,9 @@
  *   2. Losers' alternateStreams fold into the survivor (deduped, capped at 50).
  *   3. Losers are deleted FIRST — add endpoints validate channel existence, so a
  *      deleted loser can't be concurrently assigned while step 4 runs.
- *   4. Every user referencing a loser gets the survivor added, then losers pulled.
+ *   4. Every user referencing a loser gets the survivor added, then losers pulled —
+ *      repeated until no holders remain, so in-flight assignments that validated
+ *      before the delete are re-granted the survivor instead of silently dropped.
  *
  * Safe to re-run: once collapsed, no group has more than one row per URL.
  *
@@ -88,17 +90,24 @@ async function run(): Promise<void> {
       }
       const loserIds = losers.map((l) => l._id);
       // Delete losers FIRST: add endpoints validate channel existence, so once deleted a
-      // loser id can't be concurrently assigned between the remap and the pull below.
+      // loser id can't pass validation for NEW assignments while we remap below.
       await Channel.deleteMany({ _id: { $in: loserIds } });
       // Users holding a loser keep access via the survivor; then loser refs are removed.
-      await User.updateMany(
-        { channels: { $in: loserIds } },
-        { $addToSet: { channels: survivor._id } },
-      );
-      await User.updateMany(
-        { channels: { $in: loserIds } },
-        { $pull: { channels: { $in: loserIds } } },
-      );
+      // Loop until no holders remain: an assignment validated before the delete can still
+      // land between the remap and the pull — the retry re-grants the survivor to any
+      // straggler instead of silently dropping their reference.
+      for (let pass = 0; pass < 5; pass++) {
+        const holders = await User.countDocuments({ channels: { $in: loserIds } });
+        if (holders === 0) break;
+        await User.updateMany(
+          { channels: { $in: loserIds } },
+          { $addToSet: { channels: survivor._id } },
+        );
+        await User.updateMany(
+          { channels: { $in: loserIds } },
+          { $pull: { channels: { $in: loserIds } } },
+        );
+      }
     }
   }
 

--- a/backend/src/scripts/migrations/0005-dedup-channel-urls.ts
+++ b/backend/src/scripts/migrations/0005-dedup-channel-urls.ts
@@ -8,8 +8,9 @@
  *
  *   1. Survivor per group = tested-working first, then most alternates, then oldest.
  *   2. Losers' alternateStreams fold into the survivor (deduped, capped at 50).
- *   3. Every user referencing a loser gets the survivor added, losers pulled.
- *   4. Losers are deleted.
+ *   3. Losers are deleted FIRST — add endpoints validate channel existence, so a
+ *      deleted loser can't be concurrently assigned while step 4 runs.
+ *   4. Every user referencing a loser gets the survivor added, then losers pulled.
  *
  * Safe to re-run: once collapsed, no group has more than one row per URL.
  *
@@ -86,6 +87,9 @@ async function run(): Promise<void> {
         await Channel.updateOne({ _id: survivor._id }, { $set: { alternateStreams: alts } });
       }
       const loserIds = losers.map((l) => l._id);
+      // Delete losers FIRST: add endpoints validate channel existence, so once deleted a
+      // loser id can't be concurrently assigned between the remap and the pull below.
+      await Channel.deleteMany({ _id: { $in: loserIds } });
       // Users holding a loser keep access via the survivor; then loser refs are removed.
       await User.updateMany(
         { channels: { $in: loserIds } },
@@ -95,7 +99,6 @@ async function run(): Promise<void> {
         { channels: { $in: loserIds } },
         { $pull: { channels: { $in: loserIds } } },
       );
-      await Channel.deleteMany({ _id: { $in: loserIds } });
     }
   }
 

--- a/backend/src/scripts/migrations/0005-dedup-channel-urls.ts
+++ b/backend/src/scripts/migrations/0005-dedup-channel-urls.ts
@@ -1,0 +1,125 @@
+/**
+ * Migration 0005 — Collapse exact-duplicate-URL catalog channels.
+ *
+ * Historical imports created multiple catalog rows (ownerId:null) with the SAME
+ * `channelUrl` under different channelIds (~236 groups / ~299 redundant docs in the
+ * profiled prod data). Import-time dedup now prevents new ones; this collapses the
+ * existing groups:
+ *
+ *   1. Survivor per group = tested-working first, then most alternates, then oldest.
+ *   2. Losers' alternateStreams fold into the survivor (deduped, capped at 50).
+ *   3. Every user referencing a loser gets the survivor added, losers pulled.
+ *   4. Losers are deleted.
+ *
+ * Safe to re-run: once collapsed, no group has more than one row per URL.
+ *
+ * Usage (from backend/):
+ *   npx tsx src/scripts/migrations/0005-dedup-channel-urls.ts            # DRY-RUN (default)
+ *   npx tsx src/scripts/migrations/0005-dedup-channel-urls.ts --commit   # apply changes
+ *   npm run migrate:dedup-urls -- --commit
+ *
+ * ALWAYS take a `mongodump` before running with --commit.
+ */
+import path from 'path';
+import mongoose from 'mongoose';
+
+require('dotenv').config({ path: path.resolve(__dirname, '../../../../.env') });
+
+import Channel from '../../models/Channel';
+const User = require('../../models/User');
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/firevision-iptv';
+const COMMIT = process.argv.includes('--commit');
+
+// Tested-working > untested > tested-dead; then richer alternates; then oldest row.
+function score(ch: any): number {
+  const working = ch.metadata?.isWorking === true ? 2 : ch.metadata?.isWorking == null ? 1 : 0;
+  return working * 1000 + (ch.alternateStreams?.length || 0);
+}
+
+async function run(): Promise<void> {
+  console.log(`\n=== Migration 0005: dedup channel URLs (${COMMIT ? 'COMMIT' : 'DRY-RUN'}) ===`);
+  await mongoose.connect(MONGODB_URI);
+  console.log(`Connected: ${MONGODB_URI.replace(/\/\/[^@]*@/, '//***@')}`);
+
+  const groups = await Channel.collection
+    .aggregate(
+      [
+        { $match: { ownerId: null } },
+        { $group: { _id: '$channelUrl', ids: { $push: '$_id' }, n: { $sum: 1 } } },
+        { $match: { n: { $gt: 1 } } },
+      ],
+      { allowDiskUse: true },
+    )
+    .toArray();
+
+  let losersTotal = 0;
+  let foldedAlts = 0;
+  const allLoserIds: mongoose.Types.ObjectId[] = [];
+
+  for (const g of groups) {
+    const docs: any[] = await Channel.find({ _id: { $in: g.ids } }).lean();
+    docs.sort(
+      (a, b) =>
+        score(b) - score(a) || new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
+    const survivor = docs[0];
+    const losers = docs.slice(1);
+    losersTotal += losers.length;
+
+    // Fold losers' alternates into the survivor (dedupe by URL, skip the shared primary, cap 50)
+    const alts = [...(survivor.alternateStreams || [])];
+    const seen = new Set(alts.map((a: any) => a.streamUrl).concat([survivor.channelUrl]));
+    for (const loser of losers) {
+      allLoserIds.push(loser._id);
+      for (const alt of loser.alternateStreams || []) {
+        if (alt.streamUrl && !seen.has(alt.streamUrl) && alts.length < 50) {
+          seen.add(alt.streamUrl);
+          alts.push(alt);
+          foldedAlts++;
+        }
+      }
+    }
+
+    if (COMMIT) {
+      if (alts.length !== (survivor.alternateStreams || []).length) {
+        await Channel.updateOne({ _id: survivor._id }, { $set: { alternateStreams: alts } });
+      }
+      const loserIds = losers.map((l) => l._id);
+      // Users holding a loser keep access via the survivor; then loser refs are removed.
+      await User.updateMany(
+        { channels: { $in: loserIds } },
+        { $addToSet: { channels: survivor._id } },
+      );
+      await User.updateMany(
+        { channels: { $in: loserIds } },
+        { $pull: { channels: { $in: loserIds } } },
+      );
+      await Channel.deleteMany({ _id: { $in: loserIds } });
+    }
+  }
+
+  const affectedUsers = allLoserIds.length
+    ? await User.countDocuments({ channels: { $in: allLoserIds } })
+    : 0;
+
+  console.log(`Duplicate-URL groups: ${groups.length}`);
+  console.log(`Redundant rows ${COMMIT ? 'deleted' : 'to delete'}: ${losersTotal}`);
+  console.log(`Alternates folded into survivors: ${foldedAlts}`);
+  console.log(
+    `Users ${COMMIT ? 'remapped (remaining loser refs: ' + affectedUsers + ')' : 'to remap: ' + affectedUsers}`,
+  );
+
+  if (!COMMIT) {
+    console.log(`\nDry-run complete — no changes written. Re-run with --commit to apply.`);
+  }
+
+  await mongoose.connection.close();
+  console.log('Done.\n');
+}
+
+run().catch(async (err) => {
+  console.error('\nMigration error:', err);
+  await mongoose.connection.close().catch(() => {});
+  process.exit(1);
+});

--- a/backend/src/scripts/migrations/0006-epg-trim.ts
+++ b/backend/src/scripts/migrations/0006-epg-trim.ts
@@ -1,0 +1,54 @@
+/**
+ * Migration 0006 — One-off trim of far-future EPG programs.
+ *
+ * EPG ingest is now bounded to EPG_MAX_LOOKAHEAD_HOURS (default 48h) ahead, but rows
+ * fetched before that bound (up to ~6 days ahead, ~82% of DB storage) linger until the
+ * 24h-after-endTime TTL reaps them naturally. This deletes them immediately instead of
+ * waiting days. Purely optional — skipping it just means slower reclamation.
+ *
+ * Safe to re-run: bounded ingest means nothing beyond the window comes back.
+ *
+ * Usage (from backend/):
+ *   npx tsx src/scripts/migrations/0006-epg-trim.ts            # DRY-RUN (default)
+ *   npx tsx src/scripts/migrations/0006-epg-trim.ts --commit   # apply changes
+ *   npm run migrate:epg-trim -- --commit
+ */
+import path from 'path';
+import mongoose from 'mongoose';
+
+require('dotenv').config({ path: path.resolve(__dirname, '../../../../.env') });
+
+import EpgProgram from '../../models/EpgProgram';
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/firevision-iptv';
+const COMMIT = process.argv.includes('--commit');
+const MAX_AHEAD_MS = (Number(process.env.EPG_MAX_LOOKAHEAD_HOURS) || 48) * 3600000;
+
+async function run(): Promise<void> {
+  console.log(`\n=== Migration 0006: EPG trim (${COMMIT ? 'COMMIT' : 'DRY-RUN'}) ===`);
+  await mongoose.connect(MONGODB_URI);
+  console.log(`Connected: ${MONGODB_URI.replace(/\/\/[^@]*@/, '//***@')}`);
+
+  const cutoff = new Date(Date.now() + MAX_AHEAD_MS);
+  const filter = { startTime: { $gt: cutoff } };
+
+  const total = await EpgProgram.countDocuments();
+  const beyond = await EpgProgram.countDocuments(filter);
+  console.log(`Programs: ${total} total, ${beyond} start beyond ${cutoff.toISOString()}`);
+
+  if (!COMMIT) {
+    console.log(`\nDry-run complete — no changes written. Re-run with --commit to apply.`);
+  } else if (beyond) {
+    const res = await EpgProgram.deleteMany(filter);
+    console.log(`\nDeleted ${res.deletedCount} far-future programs.`);
+  }
+
+  await mongoose.connection.close();
+  console.log('Done.\n');
+}
+
+run().catch(async (err) => {
+  console.error('\nMigration error:', err);
+  await mongoose.connection.close().catch(() => {});
+  process.exit(1);
+});

--- a/backend/src/scripts/migrations/0007-prune-orphan-refs.ts
+++ b/backend/src/scripts/migrations/0007-prune-orphan-refs.ts
@@ -1,0 +1,70 @@
+/**
+ * Migration 0007 — Remove dangling channel refs from users.channels[].
+ *
+ * Catalog wipes/re-imports that predate the "$pull refs on delete" cleanup left users
+ * holding ObjectIds of channels that no longer exist (8,731 refs across 19 users in the
+ * profiled prod data — for most, their ENTIRE list was dangling, i.e. they already see
+ * an empty channel list). Dangling refs serve nothing, bloat user docs, and inflate the
+ * $in on every channel sync. Current delete paths clean up refs, so new ones shouldn't
+ * appear; this removes the legacy ones.
+ *
+ * Safe to re-run: finds nothing once clean.
+ *
+ * Usage (from backend/):
+ *   npx tsx src/scripts/migrations/0007-prune-orphan-refs.ts            # DRY-RUN (default)
+ *   npx tsx src/scripts/migrations/0007-prune-orphan-refs.ts --commit   # apply changes
+ *   npm run migrate:prune-orphan-refs -- --commit
+ *
+ * ALWAYS take a `mongodump` before running with --commit.
+ */
+import path from 'path';
+import mongoose from 'mongoose';
+
+require('dotenv').config({ path: path.resolve(__dirname, '../../../../.env') });
+
+import Channel from '../../models/Channel';
+const User = require('../../models/User');
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/firevision-iptv';
+const COMMIT = process.argv.includes('--commit');
+
+async function run(): Promise<void> {
+  console.log(`\n=== Migration 0007: prune orphan refs (${COMMIT ? 'COMMIT' : 'DRY-RUN'}) ===`);
+  await mongoose.connect(MONGODB_URI);
+  console.log(`Connected: ${MONGODB_URI.replace(/\/\/[^@]*@/, '//***@')}`);
+
+  const channelIds = new Set(
+    (await Channel.find({}, { _id: 1 }).lean()).map((d: any) => d._id.toString()),
+  );
+
+  const users: any[] = await User.find({}, { username: 1, channels: 1 }).lean();
+  let usersAffected = 0;
+  let orphansTotal = 0;
+
+  for (const u of users) {
+    const orphans = (u.channels || []).filter((c: any) => !channelIds.has(c.toString()));
+    if (!orphans.length) continue;
+    usersAffected++;
+    orphansTotal += orphans.length;
+    console.log(`  ${u.username}: ${orphans.length} of ${u.channels.length} refs dangling`);
+    if (COMMIT) {
+      await User.updateOne({ _id: u._id }, { $pull: { channels: { $in: orphans } } });
+    }
+  }
+
+  console.log(
+    `\n${usersAffected} user(s), ${orphansTotal} dangling ref(s) ${COMMIT ? 'removed' : 'found'}.`,
+  );
+  if (!COMMIT) {
+    console.log(`Dry-run complete — no changes written. Re-run with --commit to apply.`);
+  }
+
+  await mongoose.connection.close();
+  console.log('Done.\n');
+}
+
+run().catch(async (err) => {
+  console.error('\nMigration error:', err);
+  await mongoose.connection.close().catch(() => {});
+  process.exit(1);
+});

--- a/backend/src/scripts/migrations/0008-categorize-patterns.ts
+++ b/backend/src/scripts/migrations/0008-categorize-patterns.ts
@@ -1,0 +1,78 @@
+/**
+ * Migration 0008 — Pattern-based categorization of remaining 'Uncategorized' channels.
+ *
+ * After the iptv-org backfill (0004), ~42k channels stayed Uncategorized because they
+ * come from provider/Xtream playlist dumps iptv-org doesn't index: VOD entries (series
+ * "S01 E09", movies "(2021)") and country-prefixed feeds ("DE: Sky Bundesliga"). Their
+ * names encode the category near-deterministically; this applies the same
+ * `patternCategory()` rules the import paths now use (series/movies/genre keywords/
+ * country-code prefix). No match → stays Uncategorized.
+ *
+ * Safe to re-run: categorized rows no longer match the filter.
+ *
+ * Usage (from backend/):
+ *   npx tsx src/scripts/migrations/0008-categorize-patterns.ts            # DRY-RUN (default)
+ *   npx tsx src/scripts/migrations/0008-categorize-patterns.ts --commit   # apply changes
+ *   npm run migrate:categorize-patterns -- --commit
+ *
+ * ALWAYS take a `mongodump` before running with --commit.
+ */
+import path from 'path';
+import mongoose from 'mongoose';
+
+require('dotenv').config({ path: path.resolve(__dirname, '../../../../.env') });
+
+import Channel from '../../models/Channel';
+import { resolveChannelGroups } from '../../services/import-helpers';
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/firevision-iptv';
+const COMMIT = process.argv.includes('--commit');
+
+async function run(): Promise<void> {
+  console.log(
+    `\n=== Migration 0008: pattern categorization (${COMMIT ? 'COMMIT' : 'DRY-RUN'}) ===`,
+  );
+  await mongoose.connect(MONGODB_URI);
+  console.log(`Connected: ${MONGODB_URI.replace(/\/\/[^@]*@/, '//***@')}`);
+
+  // Covers the literal 'Uncategorized', plus ''/null groups some imports left behind
+  // (group-title="" parses as an empty string, bypassing the schema default).
+  const docs: any[] = await Channel.find(
+    { $or: [{ channelGroup: 'Uncategorized' }, { channelGroup: '' }, { channelGroup: null }] },
+    { channelId: 1, channelName: 1, channelGroup: 1 },
+  ).lean();
+  console.log(`Uncategorized/empty-group channels: ${docs.length}`);
+
+  const original = new Map(docs.map((d) => [d._id.toString(), d.channelGroup]));
+  const resolved = await resolveChannelGroups(docs);
+  // Normalize unresolvable empty groups to the schema default for consistent grouping.
+  for (const d of docs) if (!d.channelGroup) d.channelGroup = 'Uncategorized';
+  const changed = docs.filter((d) => d.channelGroup !== original.get(d._id.toString()));
+  console.log(`Resolvable (iptv-org + patterns): ${resolved}`);
+
+  const byGroup = new Map<string, number>();
+  for (const d of changed) byGroup.set(d.channelGroup, (byGroup.get(d.channelGroup) || 0) + 1);
+  const top = [...byGroup.entries()].sort((a, b) => b[1] - a[1]).slice(0, 15);
+  console.log(`Top groups: ${top.map(([g, n]) => `${g}=${n}`).join(', ') || '(none)'}`);
+
+  if (!COMMIT) {
+    console.log(`\nDry-run complete — no changes written. Re-run with --commit to apply.`);
+  } else if (changed.length) {
+    const res = await Channel.bulkWrite(
+      changed.map((d) => ({
+        updateOne: { filter: { _id: d._id }, update: { $set: { channelGroup: d.channelGroup } } },
+      })),
+      { ordered: false },
+    );
+    console.log(`\nUpdated ${res.modifiedCount} channels.`);
+  }
+
+  await mongoose.connection.close();
+  console.log('Done.\n');
+}
+
+run().catch(async (err) => {
+  console.error('\nMigration error:', err);
+  await mongoose.connection.close().catch(() => {});
+  process.exit(1);
+});

--- a/backend/src/scripts/migrations/0009-fix-channel-names.ts
+++ b/backend/src/scripts/migrations/0009-fix-channel-names.ts
@@ -1,0 +1,78 @@
+/**
+ * Migration 0009 — Repair channel names corrupted by the first-comma EXTINF parse.
+ *
+ * The M3U parsers extracted the title with /,(.+)$/ — everything after the FIRST comma.
+ * Attribute values legally contain commas (Cloudinary tvg-logo URLs "fl_lossy,q_auto,…",
+ * user-agent strings "(KHTML, like Gecko)"), so ~756 stored names begin mid-attribute:
+ *
+ *   before: …Thumbnail.png",Tata Play Marathi Classics
+ *   after:  Tata Play Marathi Classics
+ *
+ * The real title always follows the LAST `",` (end of the final quoted attribute), so the
+ * repair takes the substring after it. The parsers now use extractExtinfTitle(), so new
+ * imports can't recreate this.
+ *
+ * Safe to re-run: repaired names no longer contain `",`.
+ *
+ * Usage (from backend/):
+ *   npx tsx src/scripts/migrations/0009-fix-channel-names.ts            # DRY-RUN (default)
+ *   npx tsx src/scripts/migrations/0009-fix-channel-names.ts --commit   # apply changes
+ *   npm run migrate:fix-names -- --commit
+ *
+ * ALWAYS take a `mongodump` before running with --commit.
+ */
+import path from 'path';
+import mongoose from 'mongoose';
+
+require('dotenv').config({ path: path.resolve(__dirname, '../../../../.env') });
+
+import Channel from '../../models/Channel';
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/firevision-iptv';
+const COMMIT = process.argv.includes('--commit');
+
+function repairedName(name: string): string | null {
+  const idx = name.lastIndexOf('",');
+  if (idx < 0) return null;
+  const fixed = name.slice(idx + 2).trim();
+  return fixed && fixed !== name ? fixed : null;
+}
+
+async function run(): Promise<void> {
+  console.log(`\n=== Migration 0009: fix channel names (${COMMIT ? 'COMMIT' : 'DRY-RUN'}) ===`);
+  await mongoose.connect(MONGODB_URI);
+  console.log(`Connected: ${MONGODB_URI.replace(/\/\/[^@]*@/, '//***@')}`);
+
+  const docs: any[] = await Channel.find({ channelName: /",/ }, { channelName: 1 }).lean();
+  console.log(`Corrupted names found: ${docs.length}`);
+
+  const fixes = docs
+    .map((d) => ({ _id: d._id, from: d.channelName as string, to: repairedName(d.channelName) }))
+    .filter((f): f is { _id: any; from: string; to: string } => f.to !== null);
+
+  fixes.slice(0, 5).forEach((f) => console.log(`  "${f.from.slice(0, 60)}…" → "${f.to}"`));
+  console.log(`Repairable: ${fixes.length}`);
+
+  if (!COMMIT) {
+    console.log(`\nDry-run complete — no changes written. Re-run with --commit to apply.`);
+  } else if (fixes.length) {
+    const res = await Channel.bulkWrite(
+      fixes.map((f) => ({
+        updateOne: { filter: { _id: f._id }, update: { $set: { channelName: f.to } } },
+      })),
+      { ordered: false },
+    );
+    console.log(`\nUpdated ${res.modifiedCount} channel names.`);
+    const remaining = await Channel.countDocuments({ channelName: /:\/\// });
+    console.log(`Names still containing "://" (for manual review): ${remaining}`);
+  }
+
+  await mongoose.connection.close();
+  console.log('Done.\n');
+}
+
+run().catch(async (err) => {
+  console.error('\nMigration error:', err);
+  await mongoose.connection.close().catch(() => {});
+  process.exit(1);
+});

--- a/backend/src/scripts/migrations/0009-fix-channel-names.ts
+++ b/backend/src/scripts/migrations/0009-fix-channel-names.ts
@@ -9,8 +9,9 @@
  *   after:  Tata Play Marathi Classics
  *
  * The real title always follows the LAST `",` (end of the final quoted attribute), so the
- * repair takes the substring after it. The parsers now use extractExtinfTitle(), so new
- * imports can't recreate this.
+ * repair takes the substring after it — but ONLY when the prefix shows attribute leakage
+ * (`="` or a URL), so a legitimate title like `Show "Name", Extended` is never truncated.
+ * The parsers now use extractExtinfTitle(), so new imports can't recreate this.
  *
  * Safe to re-run: repaired names no longer contain `",`.
  *
@@ -27,16 +28,10 @@ import mongoose from 'mongoose';
 require('dotenv').config({ path: path.resolve(__dirname, '../../../../.env') });
 
 import Channel from '../../models/Channel';
+import { repairLeakedExtinfName } from '../../services/import-helpers';
 
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/firevision-iptv';
 const COMMIT = process.argv.includes('--commit');
-
-function repairedName(name: string): string | null {
-  const idx = name.lastIndexOf('",');
-  if (idx < 0) return null;
-  const fixed = name.slice(idx + 2).trim();
-  return fixed && fixed !== name ? fixed : null;
-}
 
 async function run(): Promise<void> {
   console.log(`\n=== Migration 0009: fix channel names (${COMMIT ? 'COMMIT' : 'DRY-RUN'}) ===`);
@@ -46,8 +41,14 @@ async function run(): Promise<void> {
   const docs: any[] = await Channel.find({ channelName: /",/ }, { channelName: 1 }).lean();
   console.log(`Corrupted names found: ${docs.length}`);
 
+  // repairLeakedExtinfName only rewrites names whose prefix shows attribute leakage
+  // (`="` or a URL) — a legitimate title containing `",` is left untouched.
   const fixes = docs
-    .map((d) => ({ _id: d._id, from: d.channelName as string, to: repairedName(d.channelName) }))
+    .map((d) => ({
+      _id: d._id,
+      from: d.channelName as string,
+      to: repairLeakedExtinfName(d.channelName),
+    }))
     .filter((f): f is { _id: any; from: string; to: string } => f.to !== null);
 
   fixes.slice(0, 5).forEach((f) => console.log(`  "${f.from.slice(0, 60)}…" → "${f.to}"`));

--- a/backend/src/services/audit-log.ts
+++ b/backend/src/services/audit-log.ts
@@ -12,8 +12,20 @@ interface LogOptions {
   errorMessage?: string;
 }
 
+// High-volume, low-value actions we don't persist — they dominated the audit log (~81% of rows)
+// and provide little forensic value. Liveness/health probing is already visible in scheduler runs.
+const NOISY_ACTIONS = new Set([
+  'test_channel',
+  'test_channel_batch',
+  'test_channel_all',
+  'check_liveness_single',
+  'check_liveness_batch',
+]);
+
 /** Fire-and-forget audit log entry. Never throws. */
 export function audit(opts: LogOptions): void {
+  if (NOISY_ACTIONS.has(opts.action)) return;
+
   AuditLog.create({
     userId: opts.userId,
     action: opts.action,

--- a/backend/src/services/cache.ts
+++ b/backend/src/services/cache.ts
@@ -138,5 +138,6 @@ export const channelCache = new CacheService('fv:ch:', 600); // 10 min
 export const userCache = new CacheService('fv:user:', 300); // 5 min
 export const statsCache = new CacheService('fv:stats:', 300); // 5 min
 export const releaseCache = new CacheService('fv:release:', 300); // 5 min
+export const epgCache = new CacheService('fv:epg:', 300); // 5 min — matches Cache-Control max-age
 
-module.exports = { CacheService, channelCache, userCache, statsCache, releaseCache };
+module.exports = { CacheService, channelCache, userCache, statsCache, releaseCache, epgCache };

--- a/backend/src/services/epg-service.ts
+++ b/backend/src/services/epg-service.ts
@@ -302,6 +302,11 @@ class EpgService {
       // Skip programs that already ended more than 24h ago
       if (endTime.getTime() < Date.now() - 86400000) continue;
 
+      // Skip programs starting beyond the lookahead window — bounds stored EPG size.
+      // Upstream XMLTV often carries ~6 days; we only keep ~2 days ahead by default.
+      const maxAheadMs = (Number(process.env.EPG_MAX_LOOKAHEAD_HOURS) || 48) * 3600000;
+      if (startTime.getTime() > Date.now() + maxAheadMs) continue;
+
       const title = this.extractText(prog.title);
       if (!title) continue;
 

--- a/backend/src/services/epg-service.ts
+++ b/backend/src/services/epg-service.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { XMLParser } from 'fast-xml-parser';
 import { createGunzip } from 'zlib';
 import EpgProgram from '../models/EpgProgram';
+import { epgCache } from './cache';
 
 const Channel = require('../models/Channel');
 
@@ -142,6 +143,10 @@ class EpgService {
 
       const durationMs = Date.now() - startTime;
       this.lastRefreshedAt = new Date();
+
+      // Bust cached EPG responses AND the known-ids set — a refresh can introduce
+      // programs for channelEpgIds the cached set would otherwise filter out.
+      await epgCache.deletePattern('*');
 
       console.log(
         `[epg-service] EPG refresh complete: ${totalPrograms} programs upserted from ${sources.length} sources in ${durationMs}ms`,

--- a/backend/src/services/external-source-cache.ts
+++ b/backend/src/services/external-source-cache.ts
@@ -83,7 +83,8 @@ class ExternalSourceCacheService {
     }
 
     const query: Record<string, any> = { source, region };
-    const allowedStatuses = ['online', 'offline', 'error', 'unknown'];
+    // Must match the liveness.status enum — a value outside this list silently disables the filter.
+    const allowedStatuses = ['alive', 'dead', 'unknown'];
     if (
       filters.status &&
       typeof filters.status === 'string' &&

--- a/backend/src/services/import-helpers.ts
+++ b/backend/src/services/import-helpers.ts
@@ -1,0 +1,159 @@
+import { IptvOrgChannel } from '../models/IptvOrgCache';
+
+const norm = (s?: string): string => (s || '').toLowerCase().trim();
+
+/**
+ * Rule-based category from near-deterministic name patterns — provider/Xtream playlist dumps
+ * mix VOD (series episodes "S01 E09", movies "(2021)") and country-prefixed feeds ("DE: …")
+ * with no group-title. Conservative by design: returns null when unsure.
+ */
+export function patternCategory(name?: string): string | null {
+  const n = (name || '').trim();
+  if (!n) return null;
+  // VOD markers first — unambiguous
+  if (/\bs\d{1,2}\s*[·.\- ]?\s*e\d{1,3}\b/i.test(n)) return 'series';
+  if (/\((19|20)\d{2}\)\s*$/.test(n)) return 'movies';
+  // Genre keywords
+  const l = n.toLowerCase();
+  if (/\b(sports?|espn|eurosport|bundesliga|dazn|bein)\b/.test(l)) return 'sports';
+  if (/\bnews\b/.test(l)) return 'news';
+  if (/\b(movies?|cinema|kino|film)\b/.test(l)) return 'movies';
+  if (/\b(kids|cartoon|junior|disney)\b/.test(l)) return 'kids';
+  if (/\b(music|mtv|hits)\b/.test(l)) return 'music';
+  if (/\b(documentary|discovery|natgeo|history)\b/.test(l)) return 'documentary';
+  // Country-code prefix ("DE: Sky …", "USA: FOX …") → group by country code
+  const cc = n.match(/^([A-Z]{2,3})\s*[:|]/);
+  if (cc) return cc[1];
+  return null;
+}
+
+// A synthetic channelId is minted when an M3U line has no tvg-id; these are unique per row
+// and must never be treated as the same logical channel (no clubbing, no id-based category match).
+const isSynthetic = (id?: string): boolean => !id || id.startsWith('channel_');
+
+/**
+ * Resolve a channelGroup for channels that would otherwise be 'Uncategorized', by matching
+ * against the iptv-org cache — first by tvg-id/channelId, then by normalized name. Mutates each
+ * channel in place and returns how many were resolved. Unmatched channels keep 'Uncategorized'.
+ * This is why imports stop producing a mostly-uncategorized catalog.
+ */
+export async function resolveChannelGroups(channels: any[]): Promise<number> {
+  const needsGroup = channels.filter((c) => !c.channelGroup || c.channelGroup === 'Uncategorized');
+  if (needsGroup.length === 0) return 0;
+
+  const catalog: any[] = await IptvOrgChannel.find(
+    {},
+    { channelId: 1, channelName: 1, categories: 1 },
+  ).lean();
+
+  const byId = new Map<string, string>();
+  const byName = new Map<string, string>();
+  for (const m of catalog) {
+    const cat = m.categories?.[0];
+    if (!cat) continue;
+    if (m.channelId && !byId.has(m.channelId)) byId.set(m.channelId, cat);
+    const n = norm(m.channelName);
+    if (n && !byName.has(n)) byName.set(n, cat);
+  }
+
+  let resolved = 0;
+  for (const c of needsGroup) {
+    const cat =
+      (!isSynthetic(c.channelId) && byId.get(c.channelId)) ||
+      byName.get(norm(c.channelName)) ||
+      patternCategory(c.channelName);
+    if (cat) {
+      c.channelGroup = cat;
+      resolved++;
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Collapse parsed channels that share a real tvg-id into one channel + alternateStreams
+ * (capped at 50). Synthetic ids are treated as unique (never clubbed). Returns the deduped list —
+ * so a multi-stream import yields one channel with fallbacks instead of N separate rows.
+ */
+export function clubByChannelId(channels: any[]): any[] {
+  const result: any[] = [];
+  const byId = new Map<string, any>();
+
+  for (const ch of channels) {
+    if (isSynthetic(ch.channelId) || !byId.has(ch.channelId)) {
+      if (!isSynthetic(ch.channelId)) byId.set(ch.channelId, ch);
+      result.push(ch);
+      continue;
+    }
+    // Same logical channel already seen — fold this URL in as an alternate.
+    const primary = byId.get(ch.channelId);
+    if (ch.channelUrl && ch.channelUrl !== primary.channelUrl) {
+      primary.alternateStreams = primary.alternateStreams || [];
+      if (
+        primary.alternateStreams.length < 50 &&
+        !primary.alternateStreams.some((a: any) => a.streamUrl === ch.channelUrl)
+      ) {
+        primary.alternateStreams.push({ streamUrl: ch.channelUrl, source: 'import' });
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Extract the display title from an #EXTINF line — the text after the comma FOLLOWING the
+ * attribute list. A naive /,(.+)$/ grabs the FIRST comma, which corrupts the name whenever an
+ * attribute value contains commas (Cloudinary tvg-logo URLs "fl_lossy,q_auto,...", user-agent
+ * strings "(KHTML, like Gecko)"). Searching from the last closing quote skips all attributes.
+ */
+export function extractExtinfTitle(line: string): string {
+  const lastQuote = line.lastIndexOf('"');
+  const commaIdx = line.indexOf(',', lastQuote >= 0 ? lastQuote : 0);
+  return commaIdx >= 0 ? line.slice(commaIdx + 1).trim() : '';
+}
+
+/**
+ * Cap how many channel refs can be added to a user's channels[] (route-level, not a schema
+ * validator — a validator would brick over-limit legacy users on ANY save, even removals).
+ */
+export function capChannelAdditions(
+  currentCount: number,
+  ids: any[],
+): { allowed: any[]; rejected: number } {
+  const max = Number(process.env.USER_CHANNELS_MAX) || 5000;
+  const room = Math.max(0, max - currentCount);
+  if (ids.length <= room) return { allowed: ids, rejected: 0 };
+  return { allowed: ids.slice(0, room), rejected: ids.length - room };
+}
+
+/**
+ * Remove channels whose URL already exists in the shared catalog (ownerId:null), and de-dup
+ * within the batch itself. Prevents re-imports from re-creating duplicate catalog rows.
+ */
+export async function dedupAgainstCatalog(channels: any[]): Promise<any[]> {
+  const Channel = require('../models/Channel');
+
+  const seen = new Set<string>();
+  const batch = channels.filter((c) => {
+    if (!c.channelUrl || seen.has(c.channelUrl)) return false;
+    seen.add(c.channelUrl);
+    return true;
+  });
+  if (batch.length === 0) return batch;
+
+  const existing: any[] = await Channel.find(
+    { ownerId: null, channelUrl: { $in: batch.map((c) => c.channelUrl) } },
+    { channelUrl: 1 },
+  ).lean();
+  const existingUrls = new Set(existing.map((c) => c.channelUrl));
+  return batch.filter((c) => !existingUrls.has(c.channelUrl));
+}
+
+module.exports = {
+  resolveChannelGroups,
+  clubByChannelId,
+  dedupAgainstCatalog,
+  capChannelAdditions,
+  patternCategory,
+  extractExtinfTitle,
+};

--- a/backend/src/services/import-helpers.ts
+++ b/backend/src/services/import-helpers.ts
@@ -115,6 +115,8 @@ export function extractExtinfTitle(line: string): string {
 /**
  * Cap how many channel refs can be added to a user's channels[] (route-level, not a schema
  * validator — a validator would brick over-limit legacy users on ANY save, even removals).
+ * This pre-check is best-effort under concurrency (the count is a snapshot); pair $addToSet
+ * updates with withChannelCapFilter() below for an atomic backstop.
  */
 export function capChannelAdditions(
   currentCount: number,
@@ -124,6 +126,33 @@ export function capChannelAdditions(
   const room = Math.max(0, max - currentCount);
   if (ids.length <= room) return { allowed: ids, rejected: 0 };
   return { allowed: ids.slice(0, room), rejected: ids.length - room };
+}
+
+/**
+ * Update filter enforcing the channels cap atomically at write time — closes the window
+ * where two concurrent imports both observe room and overshoot USER_CHANNELS_MAX.
+ * The update matches nothing (matchedCount 0) when the addition would exceed the cap.
+ */
+export function withChannelCapFilter(userId: any, addCount: number): Record<string, any> {
+  const max = Number(process.env.USER_CHANNELS_MAX) || 5000;
+  return {
+    _id: userId,
+    $expr: { $lte: [{ $size: { $ifNull: ['$channels', []] } }, max - addCount] },
+  };
+}
+
+/**
+ * Repair a channel name corrupted by the old first-comma EXTINF parse. Only rewrites when
+ * the prefix before the last `",` shows attribute leakage (a quoted attribute or a URL) —
+ * a legitimate title like `Show "Name", Extended` is left untouched.
+ */
+export function repairLeakedExtinfName(name: string): string | null {
+  const idx = name.lastIndexOf('",');
+  if (idx < 0) return null;
+  const prefix = name.slice(0, idx);
+  if (!prefix.includes('="') && !prefix.includes('://')) return null;
+  const fixed = name.slice(idx + 2).trim();
+  return fixed && fixed !== name ? fixed : null;
 }
 
 /**
@@ -154,6 +183,8 @@ module.exports = {
   clubByChannelId,
   dedupAgainstCatalog,
   capChannelAdditions,
+  withChannelCapFilter,
+  repairLeakedExtinfName,
   patternCategory,
   extractExtinfTitle,
 };

--- a/backend/src/services/stream-health-service.ts
+++ b/backend/src/services/stream-health-service.ts
@@ -1,5 +1,6 @@
 import Channel from '../models/Channel';
 import { probeStream } from './stream-prober';
+import { channelCache } from './cache';
 import type { IChannelDocument } from '@firevision/shared';
 
 const BATCH_SIZE = 200;
@@ -75,6 +76,12 @@ class StreamHealthService {
     console.log(
       `[stream-health] Complete: ${stats.checked} checked, ${stats.promoted} promoted, ${stats.allDead} all-dead, ${stats.flaggedSkipped} flagged-skipped`,
     );
+
+    // Promotions swap channelUrl / mutate liveness in the cached catalog payload —
+    // bust it so clients pick up the promoted streams (shared Redis with the API).
+    if (stats.promoted > 0) {
+      await channelCache.deletePattern('catalog:*');
+    }
 
     return stats;
   }

--- a/backend/src/services/task-registry.ts
+++ b/backend/src/services/task-registry.ts
@@ -2,7 +2,8 @@ import { iptvOrgCacheService } from './iptv-org-cache';
 import { externalSourceCacheService } from './external-source-cache';
 import { epgService } from './epg-service';
 import { streamHealthService } from './stream-health-service';
-import { ExternalSourceCacheMeta } from '../models/ExternalSourceCache';
+import { ExternalSourceCacheMeta, ExternalSourceChannel } from '../models/ExternalSourceCache';
+import { IptvOrgChannel } from '../models/IptvOrgCache';
 
 export interface SubtaskResult {
   name: string;
@@ -91,6 +92,39 @@ async function livenessHandler(): Promise<TaskResult> {
       durationMs: 0,
       error: err.message,
     });
+  }
+
+  // Prune stale dead cache rows right after the sweep re-confirmed their state.
+  // Opt-in; caches are regenerable, so a still-listed stream re-imports on next refresh.
+  if (process.env.DEAD_STREAM_PRUNE_ENABLED === 'true') {
+    const pruneStart = Date.now();
+    try {
+      const parsedDays = Number(process.env.DEAD_STREAM_PRUNE_DAYS);
+      const days = Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : 7;
+      const cutoff = new Date(Date.now() - days * 86400000);
+      const filter = { 'liveness.status': 'dead', 'liveness.lastCheckedAt': { $lt: cutoff } };
+      const [iptv, ext] = await Promise.all([
+        IptvOrgChannel.deleteMany(filter),
+        ExternalSourceChannel.deleteMany(filter),
+      ]);
+      subtasks.push({
+        name: 'prune-dead-streams',
+        status: 'completed',
+        durationMs: Date.now() - pruneStart,
+        result: {
+          iptvOrgDeleted: iptv.deletedCount || 0,
+          externalDeleted: ext.deletedCount || 0,
+          olderThanDays: days,
+        },
+      });
+    } catch (err: any) {
+      subtasks.push({
+        name: 'prune-dead-streams',
+        status: 'failed',
+        durationMs: Date.now() - pruneStart,
+        error: err.message,
+      });
+    }
   }
 
   const completed = subtasks.filter((s) => s.status === 'completed').length;

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -9,6 +9,7 @@ declare namespace Express {
       channelListCode?: string;
       isActive: boolean;
       emailVerified: boolean;
+      allCatalog?: boolean;
     };
     sessionId?: string;
     jwt?: {

--- a/docs/FEATURE_LIST.md
+++ b/docs/FEATURE_LIST.md
@@ -596,3 +596,26 @@ Complete inventory of every feature in the application.
 - Import dedup is scoped per user, so re-importing a playlist won't create duplicates
 - "Browse Demo Channels" pairs to a dedicated `DEMO_CHANNEL_LIST_CODE`; the admin/TV channel sync is bounded by `TV_CHANNELS_MAX`
 - One-time migration backfills ownership with conservative attribution and guarantees no user loses channels
+
+## Database Growth Prevention & Serving Performance
+
+- EPG ingest bounded to `EPG_MAX_LOOKAHEAD_HOURS` (default 48h) ahead — upstream guides carrying ~6 days no longer bloat storage
+- Noisy audit actions (`test_channel*`, `check_liveness*`) are no longer persisted; audit retention tightened to 180 days (TTL)
+- Scheduled task-run history auto-expires after 30 days (TTL); redundant indexes dropped from channels/iptv-org/audit collections
+- Optional scheduler step prunes stale dead cache streams after each liveness sweep (`DEAD_STREAM_PRUNE_ENABLED`, `DEAD_STREAM_PRUNE_DAYS`)
+- Migration `npm run migrate:sync-indexes` reconciles live indexes with the schemas on deploy (dry-run by default, `--commit` to apply)
+
+## Import Hygiene: Categorization, Clubbing & Dedup
+
+- M3U imports without `group-title` resolve a category from the iptv-org cache (by tvg-id, then name), then from name patterns (series `S01 E09`, movies `(2021)`, genre keywords, `DE:`-style country prefixes) before falling back to `Uncategorized`
+- Multiple streams sharing a tvg-id are clubbed into one channel with `alternateStreams` (capped at 50) instead of duplicate rows
+- Admin catalog imports skip URLs already present in the catalog, so re-imports no longer create duplicate channels
+- EXTINF titles are extracted after the attribute list (not the first comma), so attribute values containing commas (Cloudinary logo URLs, user-agent strings) no longer corrupt channel names
+
+## Channel Serving: Caching, Payloads & Limits
+
+- Shared catalog responses (`/channels`, `/channels/grouped`, `/playlist.m3u`) and rendered EPG (XMLTV + JSON) are Redis-cached with invalidation on catalog mutations
+- Channel list endpoints return a whitelisted field set verified against what the TV app and web frontend actually read (~40% smaller payloads)
+- M3U playlist generation streams via a lean cursor instead of hydrating the full catalog in memory
+- Auth middleware fetches only the user fields it needs; every channel list response is bounded by `TV_CHANNELS_MAX`
+- Per-user channel lists are capped at `USER_CHANNELS_MAX` (default 5000) additions; admins can set `allCatalog` on a user to serve them the whole shared catalog instead

--- a/docs/decisions/006-prevention-in-code-over-data-cleanup.md
+++ b/docs/decisions/006-prevention-in-code-over-data-cleanup.md
@@ -1,0 +1,60 @@
+# ADR-006: Prevention in Code over Data Cleanup
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-14
+
+## Context
+
+A profiling pass over a restored production backup (413k docs, ~75 MB on-disk; see
+`docs/DB_OPTIMIZATION_ANALYSIS.md`) found several classes of accumulated data problems:
+
+- `epgprograms` was 82% of all storage because EPG ingest stored ~6 days of guide lookahead
+- 70% of the catalog (44,305 channels) sat in `Uncategorized` — two bulk M3U imports carried no
+  `group-title`, and the parser defaulted silently
+- 81% of `auditlogs` rows were `test_channel`/`check_liveness*` noise, with no TTL despite the
+  model claiming one; `scheduledtaskruns` had no TTL at all
+- ~300 duplicate-URL channel rows and dead cache streams (iptv-org 52% dead) accumulated
+  because imports and sweeps never deduped or pruned
+
+The obvious fix was a set of one-off cleanup migrations (backfill categories, delete far-future
+EPG rows, collapse duplicates). But every one of these problems would regrow, because the code
+that generates the data was the root cause.
+
+## Decision
+
+Fix the **generation and serving paths only**; do not mutate existing data.
+
+- EPG ingest drops programs beyond `EPG_MAX_LOOKAHEAD_HOURS` (default 48h) at parse time
+- `audit()` early-returns for noisy liveness/test actions; retention declared as TTL (180d audit,
+  30d task runs) and applied on deploy via `npm run migrate:sync-indexes -- --commit`
+- Imports resolve a category from the iptv-org cache before defaulting to `Uncategorized`, club
+  same-tvg-id streams into `alternateStreams`, and skip URLs already in the catalog
+- An opt-in scheduler step prunes stale dead cache rows after each liveness sweep
+
+Existing bad data is left in place: the far-future EPG backlog self-reaps through the existing
+TTL as programs age out; legacy Uncategorized/duplicate rows persist harmlessly but stop growing.
+
+## Alternatives Considered
+
+- **Cleanup migrations + code fixes together** — rejected for this pass: mutating production data
+  carries restore/rollback risk and hides whether the prevention actually works; the storage win
+  was dominated by EPG, which self-heals within days once ingest is bounded.
+- **Cleanup only, no code changes** — rejected outright: every problem regrows from the same
+  ingest paths; the next backup would show the same profile.
+- **Normalizing the catalog onto the iptv-org cache** — rejected in the analysis: measured overlap
+  is only ~20%, the cache is volatile (half-dead, refresh-truncated), and it would put a join on
+  the hottest read path.
+
+## Consequences
+
+- No production data was touched; all changes are reviewable code with unit tests (69/69 green)
+- EPG storage converges to ~40% smaller steady-state without a delete ever running
+- Legacy artifacts (44k Uncategorized, ~300 dup rows, one 19,898-ref user) remain visible until a
+  future, separately-approved cleanup — reports on old data still reflect them
+- If a cleanup is wanted later, it is now safe to write because re-imports can no longer recreate
+  what it removes

--- a/docs/decisions/007-route-level-channel-cap-and-allcatalog.md
+++ b/docs/decisions/007-route-level-channel-cap-and-allcatalog.md
@@ -1,0 +1,58 @@
+# ADR-007: Route-Level Channel Cap + allCatalog Flag (No Schema Validator)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-14
+
+## Context
+
+`users.channels[]` holds ObjectId references to catalog channels. Production data showed 128,618
+total refs across 210 users — average 612, but one user held **19,898**. That outlier made the
+non-admin channel sync build a ~280 KB `$in` query, run ~20k index point-lookups, and ship a
+~14 MB JSON response to a low-end TV stick — exactly the failure mode `TV_CHANNELS_MAX` (2000)
+already protected the admin path against. Nothing bounded how large a user's list could grow:
+every import path (`user-playlist`, `iptv-org`, `external-sources`) appended without limit.
+
+A user holding ~20k refs isn't curating a selection — they effectively want the whole catalog.
+
+## Decision
+
+Two mechanisms, both enforced in code rather than the schema:
+
+1. **Route-level growth cap.** `capChannelAdditions(currentCount, ids)` (in
+   `services/import-helpers.ts`, `USER_CHANNELS_MAX` default 5000) is applied at all five sites
+   that add to `user.channels[]`. Additions beyond the cap are skipped and logged; existing
+   over-limit users keep working.
+
+2. **`allCatalog` flag on User.** Admin-settable via the existing `PUT /users/:id` whitelist.
+   Flagged users are served the shared catalog query (`{ ownerId: null }`, capped at
+   `TV_CHANNELS_MAX`, shared Redis-cached payload) instead of a giant `$in` over their refs.
+   This is the intended migration path for the 19,898-ref account.
+
+Additionally, every channel-list response (admin and user) is now bounded by `TV_CHANNELS_MAX`.
+
+## Alternatives Considered
+
+- **Mongoose array-length validator on `channels`** — rejected: validators run on any `save()`
+  of a modified path, so the existing 19,898-ref user would fail validation even when _removing_
+  channels or updating unrelated fields through a save. A schema rule can't distinguish growth
+  from shrinkage.
+- **Junction collection (user_channels)** — rejected at this scale: 210 users don't justify a
+  join on the hottest read path; revisit only if user count grows ~10x.
+- **Hard-trimming the outlier user's array** — rejected: it's a data mutation (see ADR-006) and
+  silently loses a user's selection; `allCatalog` gives them strictly more instead.
+
+## Consequences
+
+- Worst-case sync drops from ~14 MB/20k-lookup to a cached, capped catalog payload
+- No user's existing data is modified; over-limit accounts degrade gracefully (additions skipped,
+  warning logged) instead of erroring
+- The cap is advisory-silent to clients today (skipped count only logged server-side); surface it
+  in the UI if users report "missing" imports
+- `allCatalog` users share the admin catalog cache entry, so flipping the flag adds no query load
+- A user at the cap who wants more channels needs an admin to either raise `USER_CHANNELS_MAX`
+  or set `allCatalog` — a deliberate support touchpoint, not self-service

--- a/frontend/src/app/(dashboard)/admin/activity/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/activity/page.tsx
@@ -54,6 +54,26 @@ function formatDate(ts: string) {
   return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
 }
 
+function ResourceCell({ log }: { log: AuditEntry }) {
+  const [expanded, setExpanded] = useState(false);
+  if (!log.resourceId) {
+    return <span className="text-sm text-muted-foreground block truncate">{log.resource}</span>;
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => setExpanded((v) => !v)}
+      aria-expanded={expanded}
+      title={expanded ? 'Click to collapse' : 'Click to show full ID'}
+      className={`block w-full min-w-0 text-left text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary ${
+        expanded ? 'whitespace-normal break-all' : 'truncate'
+      }`}
+    >
+      {log.resource}: {log.resourceId}
+    </button>
+  );
+}
+
 export default function ActivityPage() {
   const [logs, setLogs] = useState<AuditEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -165,7 +185,7 @@ export default function ActivityPage() {
       ) : (
         <DataTable<AuditEntry>
           data={logs}
-          gridTemplate="100px 140px 140px minmax(120px,1fr) 120px 120px"
+          gridTemplate="minmax(100px,1fr) minmax(110px,1.2fr) minmax(130px,1.4fr) minmax(160px,2.6fr) minmax(90px,1fr) minmax(110px,1.1fr)"
           resizable
           ariaLabel="Activity log table"
           emptyMessage="No activity logs found"
@@ -233,15 +253,7 @@ export default function ActivityPage() {
                     onChange={setSelectedResources}
                   />
                 ),
-                cell: (log) => (
-                  <span
-                    className="text-sm truncate text-muted-foreground block min-w-0"
-                    title={log.resourceId ? `${log.resource}: ${log.resourceId}` : log.resource}
-                  >
-                    {log.resource}
-                    {log.resourceId ? `: ${log.resourceId.slice(0, 8)}…` : ''}
-                  </span>
-                ),
+                cell: (log) => <ResourceCell log={log} />,
               },
               {
                 key: 'status',

--- a/frontend/src/components/channels-page-shell.tsx
+++ b/frontend/src/components/channels-page-shell.tsx
@@ -107,6 +107,11 @@ export default function ChannelsPageShell({ mode }: ChannelsPageShellProps) {
   const [error, setError] = useState('');
   const [page, setPage] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
+  const [healthStats, setHealthStats] = useState<{
+    working: number;
+    notWorking: number;
+    untested: number;
+  } | null>(null);
 
   // Column filter state
   const [filterOptions, setFilterOptions] = useState<{
@@ -275,6 +280,7 @@ export default function ChannelsPageShell({ mode }: ChannelsPageShellProps) {
         const body = res.data;
         setChannels(Array.isArray(body) ? body : body.data || body.channels || []);
         setTotalCount(body.totalCount ?? (Array.isArray(body) ? body.length : body.count || 0));
+        setHealthStats(body.health ?? null);
       } catch (err: unknown) {
         if (err instanceof Error && err.name === 'AbortError') return;
         if (
@@ -1405,9 +1411,16 @@ export default function ChannelsPageShell({ mode }: ChannelsPageShellProps) {
       {/* Stream health stats */}
       {(() => {
         const list = isAdmin ? channels : filtered;
-        const working = list.filter((c) => c.metadata?.isWorking === true).length;
-        const notWorking = list.filter((c) => c.metadata?.isWorking === false).length;
-        const untested = list.length - working - notWorking;
+        const working =
+          isAdmin && healthStats
+            ? healthStats.working
+            : list.filter((c) => c.metadata?.isWorking === true).length;
+        const notWorking =
+          isAdmin && healthStats
+            ? healthStats.notWorking
+            : list.filter((c) => c.metadata?.isWorking === false).length;
+        const untested =
+          isAdmin && healthStats ? healthStats.untested : list.length - working - notWorking;
         return (
           <div className="flex items-center gap-4 px-4 py-2.5 bg-muted/50 border border-border text-xs">
             <Zap className="h-4 w-4 text-muted-foreground shrink-0" />

--- a/packages/shared/src/types/user.types.ts
+++ b/packages/shared/src/types/user.types.ts
@@ -11,6 +11,8 @@ export interface IUser {
   isActive: boolean;
   profilePicture: string | null;
   channels: Types.ObjectId[];
+  // Serve the whole shared catalog (capped) instead of the channels[] selection.
+  allCatalog?: boolean;
   lastLogin?: Date;
   metadata?: {
     deviceName?: string;


### PR DESCRIPTION
## Summary

A production DB snapshot analysis found that most storage/quality problems were caused by the code that writes and serves data. This PR fixes the generation paths so the problems stop recurring, adds a Redis-backed serving layer, and ships validated cleanup migrations for the existing data.

### Growth prevention
- EPG ingest bounded to `EPG_MAX_LOOKAHEAD_HOURS` (default 48h) — upstream guides carry ~6 days and were **82% of DB storage**
- Noisy `test_channel`/`check_liveness*` audit actions (81% of rows) no longer persisted; audit retention 365d → 180d, task-run history gets a 30d TTL
- Fixed duplicate index declarations that silently prevented the audit TTL **and** the scheduler run-lock index from ever building in production
- Optional dead-stream pruning of regenerable caches after liveness sweeps

### Import hygiene
- Imports resolve a category (iptv-org → name patterns) before defaulting to `Uncategorized` — bulk imports had left **70% of the catalog uncategorized**
- Same-tvg-id streams club into `alternateStreams` instead of duplicate rows; catalog re-imports skip existing URLs
- EXTINF titles parsed after the attribute list — comma-containing attribute values (Cloudinary logo URLs, user-agents) had corrupted 756 channel names
- Per-user channel list growth capped at `USER_CHANNELS_MAX` (default 5000)

### Serving performance
- Redis caching (previously defined but unused) for catalog list/grouped, M3U playlist, and EPG responses, invalidated on catalog mutations
- Whitelisted list payloads (~40% smaller, verified against what the TV app and web frontend actually read); streamed M3U generation; projected auth fetches
- EPG `$in` pre-intersected against ids that have guide data (~100k → ~1.7k)
- Every channel list bounded by `TV_CHANNELS_MAX`; new admin-settable `allCatalog` user flag
- Fix: external-source `?status=` filter compared against legacy status values and never filtered

### Cleanup migrations (0003–0009, dry-run by default)
Index sync, category backfill, duplicate-URL collapse, EPG trim, orphan-ref pruning, pattern categorization, name repair. All validated end-to-end against a restored production copy: **75 → 58.8 MB on-disk, 0 duplicate URLs, 0 corrupted names, 0 orphan refs, Uncategorized 70% → 13.5%.**

## Test plan
- [x] `npm run typecheck` clean (shared + backend)
- [x] `npm run lint` — 0 errors
- [x] 85/85 backend tests, incl. 25 new unit tests (import helpers, EXTINF parsing, pattern categorization, caps)
- [x] All migrations dry-run + committed against a restored prod snapshot; verified counts before/after
- [x] Live-verified on the dev stack: bounded EPG refresh, TTL auto-purge, cache hits, clean imports

## Deploy notes
After this merges and the release tag deploys, run in order inside the backend container (each dry-runs first; take a `mongodump` before committing):
`migrate:sync-indexes` → `migrate:categorize` → `migrate:dedup-urls` → `migrate:epg-trim` → `migrate:prune-orphan-refs` → `migrate:categorize-patterns` → `migrate:fix-names`

New env vars (all defaulted): `EPG_MAX_LOOKAHEAD_HOURS`, `DEAD_STREAM_PRUNE_ENABLED`, `DEAD_STREAM_PRUNE_DAYS`, `USER_CHANNELS_MAX`