### PR TITLE
Fix production Redis DNS clash and container healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,10 @@ RUN mkdir -p uploads apks && \
 # Expose port
 EXPOSE 3000
 
-# Health check
+# Health check — 127.0.0.1, not localhost: Node 18 resolves localhost to ::1 first
+# and the app listens on IPv4, so the check would fail with ECONNREFUSED ::1.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+  CMD node -e "require('http').get('http://127.0.0.1:3000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
 
 # Run as non-root user
 RUN addgroup -g 1001 -S nodejs && \

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -34,8 +34,13 @@ COPY --from=builder /app/frontend/public ./frontend/public
 
 EXPOSE 3000
 
+# Docker sets HOSTNAME to the container id, which makes the Next.js standalone server
+# bind only the container IP — no loopback healthcheck can ever pass. Bind everywhere.
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
 HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
-  CMD curl -f http://localhost:3000/ || exit 1
+  CMD curl -f http://127.0.0.1:3000/ || exit 1
 
 # Run as non-root user
 RUN addgroup -g 1001 -S nodejs && \

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -8,7 +8,10 @@ services:
       PORT: 3000
       APP_VERSION: ${APP_VERSION}
       MONGODB_URI: mongodb://mongodb:27017/firevision-iptv
-      REDIS_URL: redis://redis:6379
+      # container_name, not the service name: the api/frontend also sit on the shared
+      # gkz-network where another stack's redis carries the alias "redis" (and requires
+      # auth) — the bare name resolves there and fails with NOAUTH.
+      REDIS_URL: redis://firevision-redis:6379
       JWT_ACCESS_SECRET: ${JWT_ACCESS_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
@@ -107,7 +110,10 @@ services:
     environment:
       NODE_ENV: production
       MONGODB_URI: mongodb://mongodb:27017/firevision-iptv
-      REDIS_URL: redis://redis:6379
+      # container_name, not the service name: the api/frontend also sit on the shared
+      # gkz-network where another stack's redis carries the alias "redis" (and requires
+      # auth) — the bare name resolves there and fails with NOAUTH.
+      REDIS_URL: redis://firevision-redis:6379
       LIVENESS_CHECK_INTERVAL_MS: ${LIVENESS_CHECK_INTERVAL_MS}
       EPG_REFRESH_INTERVAL_MS: ${EPG_REFRESH_INTERVAL_MS}
       CACHE_REFRESH_INTERVAL_MS: ${CACHE_REFRESH_INTERVAL_MS}
@@ -118,6 +124,10 @@ services:
         '-c',
         'echo "Waiting 5m for API to settle..." && sleep 300 && npx tsx backend/src/scheduler-entrypoint.ts',
       ]
+    # The backend image's HEALTHCHECK probes the HTTP port, but the scheduler runs no
+    # HTTP server — it would show unhealthy forever. Disable the inherited check.
+    healthcheck:
+      disable: true
     depends_on:
       - mongodb
       - redis


### PR DESCRIPTION
## Summary

Two production infrastructure bugs found while validating the v1.3.0 rollout:

### 1. Redis unreachable (NOAUTH) — cache layer inactive
The api/frontend containers are attached to both `firevision-network` and the shared `gkz-network`. Another stack's redis (`gkz-uat-redis`) carries the DNS alias `redis` on that shared network and requires a password, so `REDIS_URL: redis://redis:6379` resolved to the wrong instance and every connection failed with `NOAUTH Authentication required` — the app fell back to no-op caching.

**Fix:** point `REDIS_URL` at the container name `firevision-redis`, which resolves unambiguously (verified via `getent hosts` inside the running api container).

### 2. Containers permanently "unhealthy" (cosmetic but misleading)
- **api:** the image HEALTHCHECK probed `http://localhost:3000` — Node 18 resolves `localhost` to `::1` first while the app listens on IPv4 → `ECONNREFUSED ::1` on every probe.
- **frontend:** Docker sets `HOSTNAME` to the container id, which makes the Next.js standalone server bind only the container IP — no loopback probe could ever pass. Now binds `0.0.0.0` and probes `127.0.0.1`.
- **scheduler:** reuses the backend image whose HEALTHCHECK probes the HTTP port, but it runs no HTTP server → unhealthy forever. The inherited check is disabled in the compose file.

## Test plan
- [x] `docker compose -f docker-compose.production.yml config` validates; rendered output shows both `REDIS_URL: redis://firevision-redis:6379` and `healthcheck: disable: true`
- [x] `firevision-redis` confirmed resolvable from inside the running prod api container; the clashing alias only exists on the shared network
- [ ] After deploy: `/health` reports `redis: "connected"`; `docker ps` shows api/frontend healthy and scheduler without a health status

## Deploy notes
Tag after merge (v1.3.1) — images rebuild with the healthcheck fixes and the stack redeploys with the corrected env. No app-code changes.